### PR TITLE
Execute partial traj

### DIFF
--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -283,7 +283,7 @@ class CcaRos : public rclcpp::Node
     constexpr static std::chrono::seconds joint_states_read_timeout_{5}; /**< Timeout for reading joint states. */ 
     constexpr static std::chrono::seconds val_and_viz_ss_avail_wait_{1}; /**< How long to wait for the validation service to be available. */ 
     constexpr static std::chrono::seconds ex_as_avail_wait_{1}; /**< How long to wait for the execution action servers to be available. */ 
-    constexpr static int partial_traj_failure_threshold_ = 2; /**< Threshold for partial trajectory failure. */
+    constexpr double traj_completion_threshold_ = 0.5; /**< Completion threshold for partial trajectory execution. Planner needs to generate at least 50%. */
     constexpr static double start_state_tolerance_ = 1e-1; /**< Tolerance for start state deviation check during execution. */
     std::shared_ptr<Status> status_{nullptr};                 /**< Current status of planning and execution. */
     std::shared_ptr<Status> robot_result_status_ = {

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -137,6 +137,7 @@ struct PlanningRequest
                                                                                       */
     bool execute_trajectory = false; /**< Whether to execute the planned trajectory. */
     bool execute_partial_trajectory = false; /**< Whether to execute partially planned trajectory. */
+    std::chrono::seconds execution_timeout{60}; /**< Timeout for trajectory execution. CcaRos returns failure sends a cancel request to the trajectory execution server if this timeout is exceeded. */ 
     TrajectoryTimeStep time_step;    /**< Time steps for the trajectory. */
 };
 
@@ -280,7 +281,6 @@ class CcaRos : public rclcpp::Node
   private:
     std::unordered_map<std::string, cca_ros::PlanningGroupInfo> planning_group_info_map_; /**< Mapping of planning group names to their information. */
     constexpr static double tf_lookup_timeout_ = 1.5; /**< Wait until 1.5 secs for TF lookups */
-    constexpr static std::chrono::seconds execution_result_timeout_{20}; /**< Timeout for execution result checking. */ 
     constexpr static std::chrono::seconds joint_states_read_timeout_{5}; /**< Timeout for reading joint states. */ 
     constexpr static std::chrono::seconds val_and_viz_ss_avail_wait_{1}; /**< How long to wait for the validation service to be available. */ 
     constexpr static std::chrono::seconds ex_as_avail_wait_{1}; /**< How long to wait for the execution action servers to be available. */ 
@@ -362,9 +362,10 @@ class CcaRos : public rclcpp::Node
      * @param goal_msg Goal messages for robot, gripper, and combined
      * trajectories.
      * @param includes_gripper_trajectory Whether gripper trajectory is included.
+     * @param execution_timeout Timeout for trajectory execution. If the trajectory execution server does not return a result within this timeout, CcaRos will send a cancel request and return FAILURE status.
      * @return True if execution succeeds, false otherwise.
      */
-    bool execute_(const cca_ros::GoalMsg &goal_msg, bool includes_gripper_trajectory);
+    bool execute_(const cca_ros::GoalMsg &goal_msg, bool includes_gripper_trajectory, const std::chrono::seconds& execution_timeout);
 
     /**
      * @brief Sends an execution goal to the specified action server.
@@ -420,8 +421,9 @@ class CcaRos : public rclcpp::Node
      * updates the node status.
      * @param st Stop token to handle thread cancellation.
      * @param includes_gripper_trajectory Whether gripper trajectory is included in the current task.
+     * @param execution_timeout Timeout for waiting for execution results before canceling execution request and returning FAILURE.
      */
-    void check_execution_result_status_(std::stop_token st, bool includes_gripper_trajectory);
+    void check_execution_result_status_(std::stop_token st, bool includes_gripper_trajectory, const std::chrono::seconds& execution_timeout);
 
     /**
      * @brief Creates goal messages for robot, gripper, and combined trajectories.

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -136,6 +136,7 @@ struct PlanningRequest
         KinematicState{Eigen::VectorXd(), std::numeric_limits<double>::quiet_NaN()}; /**< Initial kinematic state.
                                                                                       */
     bool execute_trajectory = false; /**< Whether to execute the planned trajectory. */
+    bool execute_partial_trajectory = false; /**< Whether to execute partially planned trajectory. */
     TrajectoryTimeStep time_step;    /**< Time steps for the trajectory. */
 };
 
@@ -283,7 +284,7 @@ class CcaRos : public rclcpp::Node
     constexpr static std::chrono::seconds joint_states_read_timeout_{5}; /**< Timeout for reading joint states. */ 
     constexpr static std::chrono::seconds val_and_viz_ss_avail_wait_{1}; /**< How long to wait for the validation service to be available. */ 
     constexpr static std::chrono::seconds ex_as_avail_wait_{1}; /**< How long to wait for the execution action servers to be available. */ 
-    constexpr double traj_completion_threshold_ = 0.5; /**< Completion threshold for partial trajectory execution. Planner needs to generate at least 50%. */
+    constexpr static double traj_completion_threshold_ = 0.5; /**< Completion threshold for partial trajectory execution. Planner needs to generate at least 50%. */
     constexpr static double start_state_tolerance_ = 1e-1; /**< Tolerance for start state deviation check during execution. */
     std::shared_ptr<Status> status_{nullptr};                 /**< Current status of planning and execution. */
     std::shared_ptr<Status> robot_result_status_ = {

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -90,6 +90,7 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
     const cca_ros::PlanningRequest& first_req = planning_requests.front();
     const bool execute_trajectory = first_req.execute_trajectory; // All requests have the same value due to validation
     const bool execute_partial_trajectory = first_req.execute_partial_trajectory; // All requests have the same value due to validation
+    const std::chrono::seconds& execution_timeout = first_req.execution_timeout; // All requests have the same value due to validation
     ex_as_names_ = planning_group_info_map_.at(first_req.planning_group).ex_as_names; // Need this for create_goal_msg_ as well as execute_
     ex_clients_ = planning_group_info_map_.at(first_req.planning_group).ex_clients; // Might as well extract here too although only needed in execute_
 
@@ -454,7 +455,7 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
 
     if (execute_trajectory) {
 
-        if (!this->execute_(final_goal_msg, includes_gripper_trajectory)) {
+        if (!this->execute_(final_goal_msg, includes_gripper_trajectory, execution_timeout)) {
             RCLCPP_ERROR(node_logger_, 
                 "Validated trajectory execution failed. See robot server side for more info.");
             *status_ = Status::FAILED;
@@ -598,6 +599,7 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
     const bool robot_only_trajectory = !gripper_goal_specified;
     const bool execute_trajectory = reqs.front().execute_trajectory;
     const bool execute_partial_trajectory = reqs.front().execute_partial_trajectory;
+    const std::chrono::seconds& execution_timeout = reqs.front().execution_timeout;
     const ExecutionActionServerNames& ex_as_names = planning_group_info_map_.at(reqs.front().planning_group).ex_as_names;
     const bool robot_ex_as_exists = !ex_as_names.robot.empty();
     const bool gripper_ex_as_exists = !ex_as_names.gripper.empty() || !ex_as_names.robot_and_gripper.empty();
@@ -642,6 +644,11 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
                 throw std::invalid_argument(
                     index_log + "Inconsistent execute trajectory specification. All tasks must either be executed together or none of them.");
             }
+            // Ensure all tasks have the same execution timeout
+	    if (req.execution_timeout != execution_timeout) {
+		throw std::invalid_argument(
+		    index_log + "Inconsistent execution timeout specification. All tasks must have the same execution timeout, although this timeout is applied for the entire trajectory.");
+	    }
         }
         
         // Validate frame_name is supplied if asked to lookup screw_info from frame name
@@ -879,7 +886,7 @@ cca_ros_msgs::srv::CcaRosValAndViz::Response::SharedPtr CcaRos::validate_and_vis
 
 }
 
-bool CcaRos::execute_(const cca_ros::GoalMsg& goal_msg, bool includes_gripper_trajectory){
+bool CcaRos::execute_(const cca_ros::GoalMsg& goal_msg, bool includes_gripper_trajectory, const std::chrono::seconds& execution_timeout){
 
     // Setup goal options for sending trajectory goals
     auto robot_send_goal_options = rclcpp_action::Client<FollowJointTrajectory>::SendGoalOptions();
@@ -895,7 +902,7 @@ bool CcaRos::execute_(const cca_ros::GoalMsg& goal_msg, bool includes_gripper_tr
         {
             // Start a thread to check result status
             robot_result_status_ = std::make_shared<cca_ros::Status>(cca_ros::Status::PROCESSING);
-            result_status_thread_ = std::jthread([this, includes_gripper_trajectory](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory);});
+            result_status_thread_ = std::jthread([this, includes_gripper_trajectory](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory, execution_timeout);});
 
 	    // Execute combined trajectory for robot and gripper
             return this->send_execution_goal_(ex_clients_.robot_and_gripper, robot_send_goal_options,
@@ -914,7 +921,7 @@ bool CcaRos::execute_(const cca_ros::GoalMsg& goal_msg, bool includes_gripper_tr
             // Start a thread to check result status
             robot_result_status_ = std::make_shared<cca_ros::Status>(cca_ros::Status::PROCESSING);
             gripper_result_status_ = std::make_shared<cca_ros::Status>(cca_ros::Status::PROCESSING);
-            result_status_thread_ = std::jthread([this, includes_gripper_trajectory](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory);});
+            result_status_thread_ = std::jthread([this, includes_gripper_trajectory](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory, execution_timeout);});
     
             // Execute trajectories for both robot and gripper
             return (this->send_execution_goal_(ex_clients_.robot, robot_send_goal_options,
@@ -927,7 +934,7 @@ bool CcaRos::execute_(const cca_ros::GoalMsg& goal_msg, bool includes_gripper_tr
     {
         // Start a thread to check result status
         robot_result_status_ = std::make_shared<cca_ros::Status>(cca_ros::Status::PROCESSING);
-        result_status_thread_ = std::jthread([this, includes_gripper_trajectory](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory);});
+        result_status_thread_ = std::jthread([this, includes_gripper_trajectory](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory, execution_timeout);});
 
         // Execute only robot trajectory
         return this->send_execution_goal_(ex_clients_.robot, robot_send_goal_options,
@@ -1072,7 +1079,7 @@ Status CcaRos::analyze_as_result_(const rclcpp_action::ResultCode &result_code, 
     return result_status;
 }
 
-void CcaRos::check_execution_result_status_(std::stop_token st, bool includes_gripper_trajectory)
+void CcaRos::check_execution_result_status_(std::stop_token st, bool includes_gripper_trajectory, const std::chrono::seconds& execution_timeout)
 {
    // Record start time for timeout tracking
     auto start = std::chrono::steady_clock::now();
@@ -1090,7 +1097,7 @@ void CcaRos::check_execution_result_status_(std::stop_token st, bool includes_gr
     while (!st.stop_requested() && rclcpp::ok())
     {
         // --- TIMEOUT ---
-        if (std::chrono::steady_clock::now() - start > execution_result_timeout_)
+        if (std::chrono::steady_clock::now() - start > execution_timeout)
         {
             RCLCPP_ERROR(node_logger_, "Timed out waiting for execution result on action server(s): %s", execution_as_name.c_str());
             RCLCPP_ERROR(node_logger_, "Sending cancel request and exiting.");

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -89,6 +89,7 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
     // Extract execution action server names and clients for this planning group
     const cca_ros::PlanningRequest& first_req = planning_requests.front();
     const bool execute_trajectory = first_req.execute_trajectory; // All requests have the same value due to validation
+    const bool execute_partial_trajectory = first_req.execute_partial_trajectory; // All requests have the same value due to validation
     ex_as_names_ = planning_group_info_map_.at(first_req.planning_group).ex_as_names; // Need this for create_goal_msg_ as well as execute_
     ex_clients_ = planning_group_info_map_.at(first_req.planning_group).ex_clients; // Might as well extract here too although only needed in execute_
 
@@ -380,29 +381,28 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
     planning_response.result.joint_trajectory = (includes_gripper_trajectory) ? final_goal_msg.robot_and_gripper : final_goal_msg.robot;
 
     // For single original task, check if aggregated trajectory is partial and allow small deviation
-    if (single_planning_request && is_partial) {
-        const int traj_size_difference = 
-            planning_requests.front().task_description.trajectory_density - 
-            static_cast<int>(planner_result_final.joint_trajectory.size());
+    if (single_planning_request && is_partial && execute_partial_trajectory) {
+        const double traj_completion_ratio = static_cast<double>(planner_result_final.joint_trajectory.size()) / 
+            static_cast<double>(planning_requests.front().task_description.trajectory_density);
         const double affordance_limit = 
             std::copysign(planner_result_final.joint_trajectory.back().tail(1)(0), 
                          planning_requests.front().task_description.goal.affordance);
-
-        if (std::abs(traj_size_difference) <= partial_traj_failure_threshold_) {
-            RCLCPP_WARN(node_logger_,
-                "Trajectory description: PARTIAL with %d points less than FULL. "
-                "Could be due to affordance reaching limit at %f. Try "
-                "readjusting the task to this limit. Will allow execution of trajectory, but do so with caution.",
-                traj_size_difference, affordance_limit);
-        } else {
+        
+        if (traj_completion_ratio < traj_completion_threshold_) {
             RCLCPP_ERROR(node_logger_,
-                "Trajectory description: PARTIAL. Could be due to affordance reaching limit at %f. Try "
-                "readjusting the task to this limit.", affordance_limit);
+                "Trajectory description: PARTIAL. Generated %.0f%% of the trajectory (below threshold). "
+                "Could be due to affordance reaching limit at %f.",
+                traj_completion_ratio * 100, affordance_limit);
             *status_ = Status::FAILED;
             return cca_ros::PlanningResponse();
         }
+        
+        RCLCPP_WARN(node_logger_,
+            "Trajectory description: PARTIAL. Generated %.0f%% of the trajectory. "
+            "Task description is set to execute partial trajectory. Forwarding to validation service. "
+            "Partial trajectory could be due to affordance reaching limit at %f",
+            traj_completion_ratio * 100, affordance_limit);
     }
-
     // Compute cartesian trajectory for the tool
     const std::vector<geometry_msgs::msg::Pose> cartesian_trajectory = 
         this->compute_cartesian_trajectory_(planner_result_final.joint_trajectory);
@@ -411,7 +411,37 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
     auto validation_response = this->validate_and_visualize_(
         final_goal_msg.robot, cartesian_trajectory, task_descriptions_for_val_and_viz);
     
-    if (!validation_response->success) {
+    if (validation_response->success) {
+        RCLCPP_INFO(node_logger_, "%s validation service succeeded", val_and_viz_ss_name_.c_str());
+    }
+    else if (single_planning_request && execute_partial_trajectory) {
+        // Try partial execution
+        const size_t valid_end_index = static_cast<size_t>(validation_response->valid_end_index);
+        const double traj_completion_ratio = (static_cast<double>(valid_end_index) + 1.0) / 
+                                              static_cast<double>(planning_requests.front().task_description.trajectory_density);
+        
+        if (traj_completion_ratio < traj_completion_threshold_) {
+            RCLCPP_ERROR(node_logger_, 
+                "%s validation service failed and partial trajectory completion ratio (%.2f) below threshold (%.2f). "
+		"Trajectory likely violates self-collision or joint limit constraints. Check server for more info."
+		, val_and_viz_ss_name_.c_str(), traj_completion_ratio, traj_completion_threshold_);
+            *status_ = Status::FAILED;
+            return planning_response;
+        }
+        
+        // Execute partial trajectory
+        RCLCPP_WARN(node_logger_, 
+            "%s validation service failed full trajectory validation. Executing partially validated trajectory.", 
+            val_and_viz_ss_name_.c_str());
+        const size_t partial_traj_size = valid_end_index + 1; // +1 since we want to include the valid end index itself
+        final_goal_msg.robot.trajectory.points.resize(partial_traj_size);
+        if (includes_gripper_trajectory) {
+            final_goal_msg.gripper.trajectory.points.resize(partial_traj_size);
+            final_goal_msg.robot_and_gripper.trajectory.points.resize(partial_traj_size);
+        }
+    }
+    else {
+        // Validation failed and partial execution not allowed
         RCLCPP_ERROR(node_logger_, 
             "%s validation service failed. Trajectory likely violates self-collision or joint limit constraints. "
             "Check server for more info.", val_and_viz_ss_name_.c_str());
@@ -567,6 +597,7 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
     const bool gripper_goal_specified = !std::isnan(reqs.front().task_description.goal.gripper);
     const bool robot_only_trajectory = !gripper_goal_specified;
     const bool execute_trajectory = reqs.front().execute_trajectory;
+    const bool execute_partial_trajectory = reqs.front().execute_partial_trajectory;
     const ExecutionActionServerNames& ex_as_names = planning_group_info_map_.at(reqs.front().planning_group).ex_as_names;
     const bool robot_ex_as_exists = !ex_as_names.robot.empty();
     const bool gripper_ex_as_exists = !ex_as_names.gripper.empty() || !ex_as_names.robot_and_gripper.empty();
@@ -633,6 +664,16 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
             throw std::invalid_argument(
                 index_log + "task_description.canonical_pose_from: method FROM_FRAME_NAME requires frame_name, but is empty");
         }
+    }
+
+    // Require execute_trajectory to be true to be able to execute partial trajectory
+    if (execute_partial_trajectory && !execute_trajectory) {
+	throw std::invalid_argument("execute_partial_trajectory is set to true but execute_trajectory is false. execute_partial_trajectory can only be true if execute_trajectory is also true.");
+    }
+
+    // Ensure execute_partial_trajectory is used only for single planning request. It is not supported for multiple planning requests for safety and complexity reasons. 
+    if (execute_partial_trajectory && !single_planning_request) {
+	throw std::invalid_argument("execute_partial_trajectory is supported only for a single planning request");
     }
 }
 

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -902,7 +902,7 @@ bool CcaRos::execute_(const cca_ros::GoalMsg& goal_msg, bool includes_gripper_tr
         {
             // Start a thread to check result status
             robot_result_status_ = std::make_shared<cca_ros::Status>(cca_ros::Status::PROCESSING);
-            result_status_thread_ = std::jthread([this, includes_gripper_trajectory](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory, execution_timeout);});
+            result_status_thread_ = std::jthread([this, includes_gripper_trajectory, execution_timeout](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory, execution_timeout);});
 
 	    // Execute combined trajectory for robot and gripper
             return this->send_execution_goal_(ex_clients_.robot_and_gripper, robot_send_goal_options,
@@ -921,7 +921,7 @@ bool CcaRos::execute_(const cca_ros::GoalMsg& goal_msg, bool includes_gripper_tr
             // Start a thread to check result status
             robot_result_status_ = std::make_shared<cca_ros::Status>(cca_ros::Status::PROCESSING);
             gripper_result_status_ = std::make_shared<cca_ros::Status>(cca_ros::Status::PROCESSING);
-            result_status_thread_ = std::jthread([this, includes_gripper_trajectory](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory, execution_timeout);});
+            result_status_thread_ = std::jthread([this, includes_gripper_trajectory, execution_timeout](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory, execution_timeout);});
     
             // Execute trajectories for both robot and gripper
             return (this->send_execution_goal_(ex_clients_.robot, robot_send_goal_options,
@@ -934,7 +934,7 @@ bool CcaRos::execute_(const cca_ros::GoalMsg& goal_msg, bool includes_gripper_tr
     {
         // Start a thread to check result status
         robot_result_status_ = std::make_shared<cca_ros::Status>(cca_ros::Status::PROCESSING);
-        result_status_thread_ = std::jthread([this, includes_gripper_trajectory](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory, execution_timeout);});
+        result_status_thread_ = std::jthread([this, includes_gripper_trajectory, execution_timeout](std::stop_token st) {this->check_execution_result_status_(st, includes_gripper_trajectory, execution_timeout);});
 
         // Execute only robot trajectory
         return this->send_execution_goal_(ex_clients_.robot, robot_send_goal_options,

--- a/cca_ros_behavior/include/cca_ros_behavior/cca_ros_behavior.hpp
+++ b/cca_ros_behavior/include/cca_ros_behavior/cca_ros_behavior.hpp
@@ -75,7 +75,6 @@ class CcaRosAction : public BT::StatefulActionNode
     std::jthread spinner_thread_;                                    /**< Thread to spin the node. */
     std::shared_ptr<cca_ros::Status> status_{nullptr};              /**< To check the status of the CCA action. */
     std::chrono::time_point<std::chrono::steady_clock> start_time_; /**< To monitor the timeout. */
-    static constexpr int timeout_ = 20; /**< Timeout duration for the CCA action (in seconds). */
 };
 } // namespace cca_ros_behavior
 

--- a/cca_ros_behavior/include/cca_ros_behavior/cca_ros_behavior.hpp
+++ b/cca_ros_behavior/include/cca_ros_behavior/cca_ros_behavior.hpp
@@ -75,6 +75,8 @@ class CcaRosAction : public BT::StatefulActionNode
     std::jthread spinner_thread_;                                    /**< Thread to spin the node. */
     std::shared_ptr<cca_ros::Status> status_{nullptr};              /**< To check the status of the CCA action. */
     std::chrono::time_point<std::chrono::steady_clock> start_time_; /**< To monitor the timeout. */
+    std::chrono::seconds timeout_{0};                               /**< Timeout set from planning request (initialized to 0 for safety) */
+
 };
 } // namespace cca_ros_behavior
 

--- a/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
+++ b/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
@@ -34,43 +34,48 @@ BT::NodeStatus CcaRosAction::onStart()
     if (req.has_value() == reqs.has_value())
     {
         throw BT::RuntimeError(
-            "Error: Either both or none of the [cca_planning_request] or [cca_planning_requests] ports have value."
+            "Error: Either both or none of the [cca_planning_request] or [cca_planning_requests] ports have value. "
             "Please specify one and only one.");
     }
 
-    // Assign the final request based on available input. One of them is available at this point.
-    using RequestVariant = std::variant<PlanningRequestPtr, PlanningRequestsPtr>;
-    auto cca_req_variant = req.has_value() ? RequestVariant(req.value())   // Use the single request if provided
-                                           : RequestVariant(reqs.value()); // Otherwise, use multiple requests
+    // Process based on which input is available
+    cca_ros::PlanningResponse response;
 
-    // Lambda to process the requests
-    auto process_request = [this](const auto &cca_req) -> BT::NodeStatus {
+    if (req.has_value())
+    {
+        timeout_ = req.value()->execution_timeout;
+        response = node_->plan(*req.value());
+    }
+    else // reqs.has_value()
+    {
+        timeout_ = reqs.value()->front().execution_timeout;
+        response = node_->plan(*reqs.value());
+    }
 
-        // Run the CCA planner and retrieve response
-	cca_ros::PlanningResponse response = node_->plan(*cca_req);
-        const auto response_ptr = std::make_shared<cca_ros::PlanningResponse>(response);
-        setOutput("cca_planning_response", response_ptr); // Set the output port with the response regardless of success or failure
-        status_ = response.status;
-        if (!response.result.success)
-        {
-            return BT::NodeStatus::FAILURE; // Return failure if planning fails
-        }
+    // Record start time to monitor timeout
+    start_time_ = std::chrono::steady_clock::now();
 
-        // Record start time to monitor timeout
-        start_time_ = std::chrono::steady_clock::now();
+    // Put response in output port regardless of success or failure
+    const auto response_ptr = std::make_shared<cca_ros::PlanningResponse>(response);
+    setOutput("cca_planning_response", response_ptr);
 
-        return BT::NodeStatus::RUNNING; // Return running status if planning succeeds
-    };
+    // Store a pointer to the status for monitoring in onRunning
+    status_ = response.status;
 
-    // Use std::visit to handle both types
-    return std::visit([this, &process_request](auto &cca_req) { return process_request(cca_req); }, cca_req_variant);
+    // Return failure if planning fails
+    if (!response.result.success)
+    {
+        return BT::NodeStatus::FAILURE;
+    }
+
+    return BT::NodeStatus::RUNNING; // Return running status if planning succeeds
 }
 
 BT::NodeStatus CcaRosAction::onRunning()
 {
     // Check if the CCA action has timed out
     auto current_time = std::chrono::steady_clock::now();
-    if (std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time_).count() > timeout_)
+    if (std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time_) > timeout_)
     {
         RCLCPP_ERROR(node_->get_logger(), "Timed out waiting for CCA action request to complete.");
         return BT::NodeStatus::FAILURE;
@@ -81,6 +86,11 @@ BT::NodeStatus CcaRosAction::onRunning()
     {
         RCLCPP_INFO(node_->get_logger(), "CCA action successfully completed");
         return BT::NodeStatus::SUCCESS;
+    }
+    else if (*status_ == cca_ros::Status::FAILED)
+    {
+        RCLCPP_ERROR(node_->get_logger(), "CCA action may have been canceled or aborted.");
+        return BT::NodeStatus::FAILURE;
     }
     else if (*status_ == cca_ros::Status::UNKNOWN)
     {

--- a/cca_ros_msgs/srv/CcaRosValAndViz.srv
+++ b/cca_ros_msgs/srv/CcaRosValAndViz.srv
@@ -9,4 +9,5 @@ string ref_frame # reference frame for EE FK computation
 ---
 # Result
 bool success # whether planning and visualization was successful
+uint32 valid_end_index # index of the last valid point in the trajectory
 int64 validation_time_usecs # amount of microseconds taken to validate self-collision and joint limits

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -322,6 +322,8 @@ class CcaRosValAndVizServer : public rclcpp::Node
         std::chrono::microseconds total_viol_check_duration{0}; // for joint limits and collision checking
 
 	size_t pt_index = 0;
+	size_t first_violation_index = ordered_group_traj.points.size(); // Initialize to full trajectory length
+	bool violation_found = false;
         for (const auto &point : ordered_group_traj.points)
         {
             // Copy the joint trajectory point to a std::vector<double> type
@@ -393,39 +395,58 @@ class CcaRosValAndVizServer : public rclcpp::Node
 			    RCLCPP_ERROR(node_logger_, jl_err_log.c_str());
 		    }
 
-		    return;
+		    // Mark violation found and store the index, then break
+		    violation_found = true;
+		    first_violation_index = pt_index;
+		    break; 
 
 		}
             }
 	    ++pt_index;
         }
 
-	// Since no joint‐limit or self‐collision violation, now visualize the trajectory
 	// Transform the trajectory to the full robot trajectory for visualization, i.e. by adding the current state of the unplanned joints
 	trajectory_msgs::msg::JointTrajectory ordered_robot_traj = reorder_trajectory_(serv_req->joint_traj, robot_state_->getVariableNames());
 
-	moveit_msgs::msg::DisplayTrajectory display_trajectory;
-
-	// Set start state 
-	display_trajectory.trajectory_start.joint_state.name     = ordered_robot_traj.joint_names;
-	display_trajectory.trajectory_start.joint_state.position = ordered_robot_traj.points.front().positions;
-
-	// Fill out the trajectory
-	auto &robot_traj = display_trajectory.trajectory.emplace_back();
-	robot_traj.joint_trajectory = ordered_robot_traj;
-
-	// Publish the joint trajectory
-	moveit_planned_path_pub_->publish(display_trajectory);
-
-        // Publish the tool trajectory
-	for (const auto& pose : serv_req->cartesian_traj)
-	{
-	    rviz_visual_tools_->publishAxis(this->transform_pose_to_world_frame(T_w_r, pose));
+	// Truncate trajectories for visualization if violation was found
+	trajectory_msgs::msg::JointTrajectory viz_joint_traj = ordered_robot_traj;
+        auto viz_cart_traj = serv_req->cartesian_traj; 
+	if (violation_found && first_violation_index > 0) {
+            // Keep only the points up to (but not including) the violation point for visualization
+	    viz_joint_traj.points.resize(first_violation_index);
+            viz_cart_traj.resize(first_violation_index);
 	}
-	rviz_visual_tools_->trigger();  // only once after batching
 
-        RCLCPP_INFO(node_logger_, "Successfully visualized requested joint trajectory");
-        serv_res->success = true;
+	if (!viz_joint_traj.points.empty()) {
+	    moveit_msgs::msg::DisplayTrajectory display_trajectory;
+
+	    // Set start state 
+	    display_trajectory.trajectory_start.joint_state.name     = viz_joint_traj.joint_names;
+	    display_trajectory.trajectory_start.joint_state.position = viz_joint_traj.points.front().positions;
+
+	    // Fill out the trajectory
+	    auto &robot_traj = display_trajectory.trajectory.emplace_back();
+	    robot_traj.joint_trajectory = viz_joint_traj;
+
+	    // Publish the joint trajectory
+	    moveit_planned_path_pub_->publish(display_trajectory);
+
+            // Publish the tool trajectory
+	    for (const auto& pose : viz_cart_traj)
+	    {
+	        rviz_visual_tools_->publishAxis(this->transform_pose_to_world_frame(T_w_r, pose));
+	    }
+	    rviz_visual_tools_->trigger();  // only once after batching
+        }
+
+	// Set success based on whether violation was found
+	if (violation_found) {
+	    RCLCPP_WARN(node_logger_, "Visualized trajectory up to violation point (first %zu points)", first_violation_index);
+	    serv_res->success = false;
+	} else {
+	    RCLCPP_INFO(node_logger_, "Successfully validated and visualized requested joint trajectory");
+	    serv_res->success = true;
+	}
         serv_res->validation_time_usecs = total_viol_check_duration.count(); // in microseconds
     }
 };

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -350,7 +350,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
 
 		// Check and store violation check
 		bool joint_limit_violation = !goal_state.satisfiesBounds(joint_model_group_);
-		psm_->getPlanningScene()->checkSelfCollision(collision_request, collision_result, goal_state);
+		lscene->checkSelfCollision(collision_request, collision_result, goal_state);
 		bool self_collision_violation = collision_result.collision;
 
 		// Capture how long it took to check for violations

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -196,7 +196,8 @@ class CcaRosValAndVizServer : public rclcpp::Node
     // Reorders the trajectory to match a given joint name order (e.g., for a planning group or the full robot)
     trajectory_msgs::msg::JointTrajectory reorder_trajectory_(
         const trajectory_msgs::msg::JointTrajectory &input_traj,
-        const std::vector<std::string> &target_joint_names)
+        const std::vector<std::string> &target_joint_names, 
+	const moveit::core::RobotState& current_state)
     {
         trajectory_msgs::msg::JointTrajectory ordered_traj;
         ordered_traj.header = input_traj.header;
@@ -207,13 +208,6 @@ class CcaRosValAndVizServer : public rclcpp::Node
         for (size_t i = 0; i < input_traj.joint_names.size(); ++i)
         {
     	name_to_index[input_traj.joint_names[i]] = i;
-        }
-    
-        // Pull a fresh robot state
-        moveit::core::RobotState fresh_state(*robot_state_);
-        {
-    	planning_scene_monitor::LockedPlanningSceneRO scene(psm_);
-    	fresh_state = scene->getCurrentState();
         }
     
         // Reorder each point according to target_joint_names
@@ -233,9 +227,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
     	    }
     	    else
     	    {
-    		new_point.positions[i] = fresh_state.getVariablePosition(name);
-    		// RCLCPP_ERROR(node_logger_, "Joint '%s' missing in trajectory point. Using current robot state.",
-    		// 	     name.c_str());
+    		new_point.positions[i] = current_state.getVariablePosition(name);
     	    }
     	}
     
@@ -257,9 +249,16 @@ class CcaRosValAndVizServer : public rclcpp::Node
 
         RCLCPP_INFO(node_logger_, "Planning and visualizing the trajectory");
 
+        // Get fresh robot state
+        moveit::core::RobotState current_state(*robot_state_);
+        {
+            planning_scene_monitor::LockedPlanningSceneRO scene(psm_);
+            current_state = scene->getCurrentState();
+        }
+
         // Capture T_w_r, the HTM from world frame, usually the root frame of the urdf to the service request reference
         // frame
-        Eigen::Isometry3d T_w_r = robot_state_->getGlobalLinkTransform(serv_req->ref_frame);
+        Eigen::Isometry3d T_w_r = current_state.getGlobalLinkTransform(serv_req->ref_frame);
 
         // Validate affordance info sizes
         if (serv_req->aff_screw_axes.size() != serv_req->aff_locations.size() ||
@@ -317,7 +316,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
         }
 
 	// (Re)order trajectory to match MoveIt planning group order
-	trajectory_msgs::msg::JointTrajectory ordered_group_traj = reorder_trajectory_(serv_req->joint_traj, joint_names);
+	trajectory_msgs::msg::JointTrajectory ordered_group_traj = reorder_trajectory_(serv_req->joint_traj, joint_names, current_state);
 
         std::chrono::microseconds total_viol_check_duration{0}; // for joint limits and collision checking
 
@@ -330,7 +329,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
             std::vector<double> planning_end_state(point.positions.begin(), point.positions.end());
 
             // Set the planning goal state to that trajectory point
-            moveit::core::RobotState goal_state(*robot_state_);
+            moveit::core::RobotState goal_state(current_state); // start from current state to preserve unplanned joints
             goal_state.setJointGroupPositions(joint_model_group_, planning_end_state);
             moveit_msgs::msg::Constraints joint_goal =
                 kinematic_constraints::constructGoalConstraints(goal_state, joint_model_group_);
@@ -406,7 +405,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
         }
 
 	// Transform the trajectory to the full robot trajectory for visualization, i.e. by adding the current state of the unplanned joints
-	trajectory_msgs::msg::JointTrajectory ordered_robot_traj = reorder_trajectory_(serv_req->joint_traj, robot_state_->getVariableNames());
+	trajectory_msgs::msg::JointTrajectory ordered_robot_traj = reorder_trajectory_(serv_req->joint_traj, current_state.getVariableNames(), current_state);
 
 	// Truncate trajectories for visualization if violation was found
 	trajectory_msgs::msg::JointTrajectory viz_joint_traj = ordered_robot_traj;

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -436,9 +436,15 @@ class CcaRosValAndVizServer : public rclcpp::Node
 	    rviz_visual_tools_->trigger();  // only once after batching
         }
 
-	// Set success based on whether violation was found
+	// Set response
 	if (violation_found) {
 	    RCLCPP_WARN(node_logger_, "Visualized trajectory up to violation point (first %zu points)", first_violation_index);
+            // Index of the last valid point in the trajectory
+            if (first_violation_index > 0) {
+                serv_res->valid_end_index = static_cast<uint32_t>(first_violation_index - 1);
+            } else {
+                serv_res->valid_end_index = 0;
+            }
 	    serv_res->success = false;
 	} else {
 	    RCLCPP_INFO(node_logger_, "Successfully validated and visualized requested joint trajectory");

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -331,8 +331,6 @@ class CcaRosValAndVizServer : public rclcpp::Node
             // Set the planning goal state to that trajectory point
             moveit::core::RobotState goal_state(current_state); // start from current state to preserve unplanned joints
             goal_state.setJointGroupPositions(joint_model_group_, planning_end_state);
-            moveit_msgs::msg::Constraints joint_goal =
-                kinematic_constraints::constructGoalConstraints(goal_state, joint_model_group_);
 
             // Acquire read-only lock on the planning scene before doing anything
             {


### PR DESCRIPTION
This pull request introduces support for executing partially planned trajectories in the CCA ROS node, along with configurable execution timeouts. It adds new validation logic, improves safety checks, and replaces the previous fixed thresholds for partial trajectory execution with a more flexible completion ratio. The main changes are summarized below:

**Partial Trajectory Execution and Validation:**

* Added `execute_partial_trajectory` flag and `execution_timeout` parameter to `PlanningRequest`, allowing users to request partial trajectory execution and specify how long to wait for execution before timing out.
* Updated input validation to ensure `execute_partial_trajectory` is only allowed for single planning requests and only if `execute_trajectory` is true; also enforces consistent execution timeout across all tasks. [[1]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fR647-R651) [[2]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fR675-R684)
* Enhanced planning logic to use a completion ratio (`traj_completion_threshold_`, default 50%) instead of a fixed point difference for determining if a partial trajectory is acceptable for execution. [[1]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450L282-R287) [[2]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL383-R406)

**Execution Timeout Handling:**

* Made execution timeout configurable per request, passing it through all relevant methods and threads, and replacing the previous hardcoded timeout. [[1]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450R365-R368) [[2]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450R424-R426) [[3]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fR92-R93) [[4]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL427-R458) [[5]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL841-R889) [[6]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL857-R905) [[7]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL876-R924) [[8]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL889-R937) [[9]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL1034-R1082) [[10]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL1052-R1100) [[11]](diffhunk://#diff-3059181a673dc7d34d10c951198294f20aa22caa21a4f3fff2edcc5bca165a79L78-R79)

**Behavioral and Logging Improvements:**

* Improved logging to clearly indicate when partial trajectories are being executed, when validation fails, and when execution is aborted due to timeout or insufficient completion ratio. [[1]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL383-R406) [[2]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL414-R445)

These changes collectively provide more robust, flexible, and safer trajectory execution handling in the CCA ROS system.