### PR TITLE
Devel

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(**)",
+      "Write(**)"
+    ],
+    "deny": [
+      "Bash(*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+This file provides guidance to Claude Code when working with this repository.
+
+## Overview
+A robot-agnostic ROS2 interface for the **Closed-Chain Affordance (CCA) planner** — a motion planning library for planning joint trajectories for manipulation tasks described as linear, rotational, or screw motions. For detailed project overview, usage examples, and code tutorial, see [README.md](README.md).
+
+## Additional Guidance
+
+### Packages
+- `cca_ros` — ROS wrapper of the CCA library (core package)
+- `cca_ros_msgs` — ROS message, service, and action definitions
+- `cca_ros_util` — Utilities for working with the CCA planner (e.g. logging planning requests/results)
+- `cca_ros_action` — CCA ROS as an action server and client wrapper
+- `cca_ros_behavior` — CCA ROS as a BehaviorTree.CPP `StatefulActionNode`
+- `cca_ros_behavior_util` — Utility behavior nodes (e.g. `LogReqToFile`)
+- `cca_ros_features` — Higher-level feature library built on `cca_ros` (e.g. `getAffordativeGraspPose`)
+- `cca_ros_behavior_features` — `cca_ros_features` functions wrapped as BehaviorTree.CPP nodes
+- `cca_ros_rviz_plugin` — Interactive RViz plugin for visual planning
+- `cca_ros_val_and_viz` — Trajectory validation (joint limits + self-collision) and visualization server
+- `robot_state_recorder` — Records joint trajectories for analysis
+- `ros_cpp_util` — General ROS/C++ utilities; no CCA dependency
+
+### Architecture
+
+### Core planning flow (`cca_ros`)
+`CcaRos` is a `rclcpp::Node` subclass. Callers instantiate it, spin it, then call `.plan()` with one or more `PlanningRequest`s using a **request–response model**:
+- `PlanningRequest` — specifies `planning_group`, `task_description`, `start_state`, `execute_trajectory`, `time_step`, etc.
+- `PlanningResponse` — contains `result.success`, `result.joint_trajectory`, `result.cca_result`, and a shared `status` pointer
+
+A `std::vector<PlanningRequest>` can be passed to plan a sequence of tasks into one stitched trajectory.
+
+### Planning groups
+A robot may have multiple planning groups (e.g. `arm`, `mobile_body_and_arm`). Each group has its own kinematic chain, joint names, reference frame, tool frame, and execution action server names, stored in `planning_group_info_map_` and populated from ROS parameters at startup. Each `PlanningRequest` specifies its `planning_group`.
+
+### Validation and visualization (`cca_ros_val_and_viz`)
+After planning, `CcaRos` calls the `/cca_ros_val_and_viz` service (MoveIt-based) to validate joint limits and collision, and to visualize the trajectory in RViz. The service is fully stateless — all needed info is in the request. See `CcaRosValAndViz.srv` for the full definition.
+
+### Coding Conventions
+
+#### General
+- Each library package uses the `<package_name>` namespace, with headers in `include/<package_name>/` and implementations in `src/<package_name>/`
+- Both files begin with the author header: `////...// Author : Crasun Jans`
+- Private member variables and `static constexpr` constants: `snake_case_` (trailing underscore, e.g. `node_`)
+- Member functions: `camelCase()`
+- Header guards: `<FILENAME>_HPP_`
+- Put all includes in the header; implementation files only include their corresponding header
+- Use `std::optional<T>` as the return type for returning functions that may not produce a result.
+
+#### Adding a library
+1. `include/<package_name>/<n>.hpp` — declare and document with Doxygen
+2. `src/<package_name>/<n>.cpp` — implement; include only the corresponding header
+3. Register `.cpp` in `CMakeLists.txt` under `add_library()`
+4. Add ROS dependencies to `ament_target_dependencies()` (with `PUBLIC`), `ament_export_dependencies()`, and `package.xml`
+5. Add non-ROS dependencies to `target_link_libraries()` (with `PUBLIC`)
+6. Only list dependencies that are directly used in the package's own headers or source — do not re-list dependencies that are already transitively available through another dependency
+
+#### BehaviorTree node conventions
+- The `rclcpp::Node::SharedPtr` is provided via the blackboard key `"node"`, not as an input port
+- Default to `StatefulActionNode` over `SyncActionNode` unless explicitly stated otherwise
+- Required input ports: use `getInput<T>()` and throw `BT::RuntimeError` on missing/invalid values
+- Complex types passed as `std::shared_ptr<T>` to avoid expensive copying (e.g. `geometry_msgs::msg::PoseStamped`)
+- When a feature function exists in `cca_ros_features`, the BehaviorTree node in `cca_ros_behavior_features` should be a thin wrapper: unpack ports, call the feature function, handle the result
+
+##### StatefulActionNode lifecycle
+- `onStart()` — called once; reads ports, allocates resources, dispatches async work; returns `RUNNING` or `FAILURE`
+- `onRunning()` — called every tick while `RUNNING`; checks progress; returns `RUNNING`, `SUCCESS`, or `FAILURE`
+- `onHalted()` — called on external halt; cancels pending async operations and releases resources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,21 @@ After planning, `CcaRos` calls the `/cca_ros_val_and_viz` service (MoveIt-based)
 - `onStart()` — called once; reads ports, allocates resources, dispatches async work; returns `RUNNING` or `FAILURE`
 - `onRunning()` — called every tick while `RUNNING`; checks progress; returns `RUNNING`, `SUCCESS`, or `FAILURE`
 - `onHalted()` — called on external halt; cancels pending async operations and releases resources
+
+### Diff Constraints
+When modifying existing files, keep the diff minimal and mechanical so it is easy to review. Only make changes required for the new functionality or bug fix—no unrelated edits.
+
+Preserve exactly (byte-for-byte unless absolutely necessary):
+- All comments and docstrings
+- All variable and function names
+- All error messages and log strings
+- All formatting and indentation (including blank lines and brace placement)
+
+Do not:
+- Reformat, re-indent, or "clean up" code
+- Rename symbols unless required for correctness
+- Add or remove blank lines unnecessarily
+- Introduce trailing whitespace
+
+If code is moved, it must appear identical in the new location.
+Formatting-only changes should never appear in the diff.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Janak Panthi UT NRG
+Copyright (c) 2024, Janak Panthi, UT NRG
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -192,6 +192,22 @@ class CcaRosContext
      */
     explicit CcaRosContext(std::shared_ptr<rclcpp::Node> node);
 
+    /**
+    * @brief Returns the shared ROS node.
+    *
+    * @return Shared pointer to the ROS node.
+    */
+    std::shared_ptr<rclcpp::Node> get_node() const;
+
+    /**
+     * @brief Returns the joint names for a given planning group.
+     * @param planning_group Name of the planning group.
+     * @return Vector of joint names.
+     */
+    const std::vector<std::string> &get_joint_names(const std::string &planning_group) const;
+
+  private:
+    friend class CcaRos;
     rclcpp::Node::SharedPtr node_;                                               /**< Shared pointer to the ROS node. */
     std::unordered_map<std::string, PlanningGroupInfo> planning_group_info_map_; /**< Mapping of planning group names to their information. Read-only after construction. */
     std::unique_ptr<tf2_ros::Buffer> tf_buffer_;                                 /**< TF2 buffer for transformation lookup. Thread-safe for concurrent reads. */
@@ -200,14 +216,6 @@ class CcaRosContext
     std::condition_variable joint_states_cv_;                                    /**< Condition variable to signal availability of joint states. */
     JointState::SharedPtr latest_joint_state_msg_{nullptr};                      /**< Latest received joint state message. */
 
-  /**
-   * @brief Returns the joint names for a given planning group.
-   * @param planning_group Name of the planning group.
-   * @return Vector of joint names.
-   */
-  const std::vector<std::string> &get_joint_names(const std::string &planning_group) const;
-
-  private:
     rclcpp::Subscription<JointState>::SharedPtr joint_states_sub_;               /**< Subscriber for joint states. */
 
     /**
@@ -358,6 +366,13 @@ class CcaRos
      * @return Vector of joint names.
      */
     const std::vector<std::string> &get_joint_names(const std::string &planning_group) const;
+
+    /**
+    * @brief Returns the shared ROS node.
+    *
+    * @return Shared pointer to the ROS node.
+    */
+    std::shared_ptr<rclcpp::Node> get_node() const;
 
   private:
     std::shared_ptr<CcaRosContext> context_; /**< Shared context owning ROS node, TF, joint states subscriber, and planning group info. */

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -177,7 +177,7 @@ struct GoalMsg
  * This class manages the process of planning, visualizing, and executing
  * trajectories for robot affordances using closed-chain kinematics.
  */
-class CcaRos : public rclcpp::Node
+class CcaRos 
 {
   public:
     // Type aliases
@@ -285,6 +285,7 @@ class CcaRos : public rclcpp::Node
     static std::unordered_map<std::string, PlanningGroupInfo> get_planning_group_info_map(rclcpp::Node* node_ptr);
 
   private:
+    rclcpp::Node::SharedPtr node_; /**< Shared pointer to the ROS node. */
     std::unordered_map<std::string, cca_ros::PlanningGroupInfo> planning_group_info_map_; /**< Mapping of planning group names to their information. */
     constexpr static double tf_lookup_timeout_ = 1.5; /**< Wait until 1.5 secs for TF lookups */
     constexpr static std::chrono::seconds joint_states_read_timeout_{5}; /**< Timeout for reading joint states. */ 

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -135,6 +135,7 @@ struct PlanningRequest
     KinematicState start_state =
         KinematicState{Eigen::VectorXd(), std::numeric_limits<double>::quiet_NaN()}; /**< Initial kinematic state.
                                                                                       */
+    bool visualize_trajectory = true; /**< Whether to visualize the planned trajectory. */
     bool execute_trajectory = false; /**< Whether to execute the planned trajectory. */
     bool execute_partial_trajectory = false; /**< Whether to execute partially planned trajectory. */
     std::chrono::seconds execution_timeout{60}; /**< Timeout for trajectory execution. CcaRos returns failure sends a cancel request to the trajectory execution server if this timeout is exceeded. */ 
@@ -405,11 +406,12 @@ class CcaRos
      * @param goal FollowJointTrajectory goal for the trajectory.
      * @param cartesian_trajectory Corresponding Cartesian trajectory.
      * @param task_descriptions Descriptions of tasks for visualization.
+     * @param visualize_trajectory Whether to visualize the trajectory.
      * @return Shared pointer to the visualization service response.
      */
     cca_ros_msgs::srv::CcaRosValAndViz::Response::SharedPtr validate_and_visualize_(
         const FollowJointTrajectoryGoal &goal, const std::vector<geometry_msgs::msg::Pose> &cartesian_trajectory,
-        const std::vector<cc_affordance_planner::TaskDescription> &task_descriptions);
+        const std::vector<cc_affordance_planner::TaskDescription> &task_descriptions, bool visualize_trajectory);
 
     /**
      * @brief Executes the planned trajectory.

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -200,6 +200,13 @@ class CcaRosContext
     std::condition_variable joint_states_cv_;                                    /**< Condition variable to signal availability of joint states. */
     JointState::SharedPtr latest_joint_state_msg_{nullptr};                      /**< Latest received joint state message. */
 
+  /**
+   * @brief Returns the joint names for a given planning group.
+   * @param planning_group Name of the planning group.
+   * @return Vector of joint names.
+   */
+  const std::vector<std::string> &get_joint_names(const std::string &planning_group) const;
+
   private:
     rclcpp::Subscription<JointState>::SharedPtr joint_states_sub_;               /**< Subscriber for joint states. */
 
@@ -344,6 +351,13 @@ class CcaRos
      * @return Shared pointer to the CcaRosContext.
      */
     std::shared_ptr<CcaRosContext> get_context() const;
+
+    /**
+     * @brief Returns the joint names for a given planning group.
+     * @param planning_group Name of the planning group.
+     * @return Vector of joint names.
+     */
+    const std::vector<std::string> &get_joint_names(const std::string &planning_group) const;
 
   private:
     std::shared_ptr<CcaRosContext> context_; /**< Shared context owning ROS node, TF, joint states subscriber, and planning group info. */

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -173,6 +173,43 @@ struct GoalMsg
 };
 
 /**
+ * @brief Class owning shared ROS infrastructure for use across parallel CcaRos planners.
+ *
+ * Owns the ROS node, joint states subscriber (with mutex and condition variable for
+ * thread-safe reads), TF buffer/listener, and the read-only planning group info map.
+ * Multiple CcaRos instances may share a single CcaRosContext to avoid duplicating
+ * subscribers, TF listeners, and parameter-load overhead.
+ */
+class CcaRosContext
+{
+  public:
+    using JointState = sensor_msgs::msg::JointState;
+
+    /**
+     * @brief Constructs a CcaRosContext from an existing ROS node.
+     * @param node Shared pointer to an existing ROS node.
+     */
+    explicit CcaRosContext(std::shared_ptr<rclcpp::Node> node);
+
+    rclcpp::Node::SharedPtr node_;                                               /**< Shared pointer to the ROS node. */
+    std::unordered_map<std::string, PlanningGroupInfo> planning_group_info_map_; /**< Mapping of planning group names to their information. Read-only after construction. */
+    std::unique_ptr<tf2_ros::Buffer> tf_buffer_;                                 /**< TF2 buffer for transformation lookup. Thread-safe for concurrent reads. */
+    std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};           /**< TF2 transform listener. */
+    std::mutex joint_states_mutex_;                                              /**< Mutex to protect access to joint states. */
+    std::condition_variable joint_states_cv_;                                    /**< Condition variable to signal availability of joint states. */
+    JointState::SharedPtr latest_joint_state_msg_{nullptr};                      /**< Latest received joint state message. */
+
+  private:
+    rclcpp::Subscription<JointState>::SharedPtr joint_states_sub_;               /**< Subscriber for joint states. */
+
+    /**
+     * @brief Callback function for processing joint state updates.
+     * @param msg Incoming joint state message.
+     */
+    void joint_states_cb_(const JointState::SharedPtr msg);
+};
+
+/**
  * @brief Class representing the CC Affordance Planner node in ROS.
  * This class manages the process of planning, visualizing, and executing
  * trajectories for robot affordances using closed-chain kinematics.
@@ -197,6 +234,18 @@ class CcaRos
      * @param node Shared pointer to an existing ROS node.
      */
     explicit CcaRos(std::shared_ptr<rclcpp::Node> node);
+
+    /**
+     * @brief Constructs a CcaRos node from a shared context.
+     *
+     * Use this constructor when creating multiple planners that should share
+     * the same ROS node, joint states subscriber, TF listener, and planning
+     * group info. Retrieve the context from the first planner via get_context()
+     * and pass it to subsequent planners.
+     *
+     * @param context Shared pointer to an existing CcaRosContext.
+     */
+    explicit CcaRos(std::shared_ptr<CcaRosContext> context);
 
     /**
      * @brief Destructs a CcaRos node.
@@ -284,9 +333,19 @@ class CcaRos
     */
     static std::unordered_map<std::string, PlanningGroupInfo> get_planning_group_info_map(rclcpp::Node* node_ptr);
 
+    /**
+     * @brief Returns the shared context owned by this planner.
+     *
+     * Use this to obtain the context after constructing the first planner with
+     * the node constructor, then pass it to subsequent planners to share
+     * infrastructure.
+     *
+     * @return Shared pointer to the CcaRosContext.
+     */
+    std::shared_ptr<CcaRosContext> get_context() const;
+
   private:
-    rclcpp::Node::SharedPtr node_; /**< Shared pointer to the ROS node. */
-    std::unordered_map<std::string, cca_ros::PlanningGroupInfo> planning_group_info_map_; /**< Mapping of planning group names to their information. */
+    std::shared_ptr<CcaRosContext> context_; /**< Shared context owning ROS node, TF, joint states subscriber, and planning group info. */
     constexpr static double tf_lookup_timeout_ = 1.5; /**< Wait until 1.5 secs for TF lookups */
     constexpr static std::chrono::seconds joint_states_read_timeout_{5}; /**< Timeout for reading joint states. */ 
     constexpr static std::chrono::seconds val_and_viz_ss_avail_wait_{1}; /**< How long to wait for the validation service to be available. */ 
@@ -301,15 +360,11 @@ class CcaRos
     std::jthread result_status_thread_; /**< Thread to check the status of robot
                                            and gripper trajectory results. */
     std::mutex status_mutex_;           /**< Mutex to protect access to status_. */
-    std::mutex joint_states_mutex_;      /**< Mutex to protect access to joint states. */
-    std::condition_variable joint_states_cv_; /**< Condition variable to signal availability of joint states. */
     rclcpp::Logger node_logger_;        /**< Node-specific logger. */
     std::string val_and_viz_ss_name_;           /**< Name of the plan and visualization server. */
     ExecutionActionClients ex_clients_; /**< Action clients for trajectory execution. */
     rclcpp::Client<CcaRosValAndViz>::SharedPtr val_and_viz_client_; /**< Client for visualizing the planned trajectory. */
-    rclcpp::Subscription<JointState>::SharedPtr joint_states_sub_;     /**< Subscriber for joint states. */
-    std::unique_ptr<tf2_ros::Buffer> tf_buffer_;                       /**< TF2 buffer for transformation lookup. */
-    std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr}; /**< TF2 transform listener. */
+    std::unordered_map<std::string, ExecutionActionClients> ex_clients_map_; /**< Per-planner execution action clients for each planning group. */
 
     // Robot ROS setup data
     cca_ros::ExecutionActionServerNames ex_as_names_; /**< Current action server names for execution. */
@@ -322,10 +377,6 @@ class CcaRos
     std::string ref_frame_;                        /**< Reference frame for transformations. */
     std::string tool_frame_;                       /**< Tool frame for the robot's end-effector. */
     std::string planning_group_;                    /**< Current planning group name. */
-
-
-    ros_cpp_util::JointTrajPoint robot_joint_states_;   /**< Processed and ordered robot joint states. */
-    ros_cpp_util::JointTrajPoint gripper_joint_states_; /**< Processed and ordered gripper joint states. */
 
     std::shared_future<GoalHandleFollowJointTrajectory::SharedPtr>
         unified_gh_future_; /**< Goal handle future for the unified trajectory
@@ -342,12 +393,6 @@ class CcaRos
      * @throws std::invalid_argument If validation fails.
      */
     void validate_input_(const std::vector<cca_ros::PlanningRequest> &reqs);
-
-    /**
-     * @brief Callback function for processing joint state updates.
-     * @param msg Incoming joint state message.
-     */
-    void joint_states_cb_(const JointState::SharedPtr msg);
 
     /**
      * @brief Retrieves the joint states of the robot and gripper.

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -300,6 +300,8 @@ class CcaRos : public rclcpp::Node
     std::jthread result_status_thread_; /**< Thread to check the status of robot
                                            and gripper trajectory results. */
     std::mutex status_mutex_;           /**< Mutex to protect access to status_. */
+    std::mutex joint_states_mutex_;      /**< Mutex to protect access to joint states. */
+    std::condition_variable joint_states_cv_; /**< Condition variable to signal availability of joint states. */
     rclcpp::Logger node_logger_;        /**< Node-specific logger. */
     std::string val_and_viz_ss_name_;           /**< Name of the plan and visualization server. */
     ExecutionActionClients ex_clients_; /**< Action clients for trajectory execution. */

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -3,31 +3,6 @@
 //      Project   : cca_ros
 //      Created   : Spring 2024
 //      Author    : Janak Panthi (Crasun Jans)
-//      Copyright : Copyright© The University of Texas at Austin, 2014-2026.
-//      All rights reserved.
-//
-//      All files within this directory are subject to the following, unless
-//      an alternative license is explicitly included within the text of
-//      each file.
-//
-//      This software and documentation constitute an unpublished work
-//      and contain valuable trade secrets and proprietary information
-//      belonging to the University. None of the foregoing material may be
-//      copied or duplicated or disclosed without the express, written
-//      permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
-//      AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
-//      INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
-//      PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
-//      THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
-//      NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
-//      THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
-//      University be liable for incidental, special, indirect, direct or
-//      consequential damages or loss of profits, interruption of business,
-//      or related expenses which may arise from use of software or
-//      documentation, including but not limited to those resulting from
-//      defects in software and/or documentation, or loss or inaccuracy of
-//      data of any kind.
-//
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CCA_ROS_HPP

--- a/cca_ros/include/cca_ros/cca_ros.hpp
+++ b/cca_ros/include/cca_ros/cca_ros.hpp
@@ -193,6 +193,12 @@ class CcaRos : public rclcpp::Node
     explicit CcaRos(const std::string &node_name, const rclcpp::NodeOptions &options);
 
     /**
+     * @brief Constructs a CcaRos node.
+     * @param node Shared pointer to an existing ROS node.
+     */
+    explicit CcaRos(std::shared_ptr<rclcpp::Node> node);
+
+    /**
      * @brief Destructs a CcaRos node.
      */
     ~CcaRos();

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -6,19 +6,23 @@
 namespace cca_ros
 {
 
-// Constructor for CcaRos, initializes the node and sets up required parameters and clients.
 CcaRos::CcaRos(const std::string &node_name, const rclcpp::NodeOptions &node_options)
-    : Node(node_name, node_options),
-      node_logger_(this->get_logger()),   // Logger for the node
+    : CcaRos(std::make_shared<rclcpp::Node>(node_name, node_options))
+{}
+
+// Constructor for CcaRos, initializes the node and sets up required parameters and clients.
+CcaRos::CcaRos(std::shared_ptr<rclcpp::Node> node)
+    : node_(node),
+      node_logger_(node->get_logger()),   // Logger for the node
       val_and_viz_ss_name_("/cca_ros_val_and_viz") // Validation and visualization service name
 {
 
     // --- Required params (throw if absent) ---
-    const std::string joint_states_topic = ros_cpp_util::get_required_str_param(this, "cca_joint_states_topic");
-    const std::string robot_name = ros_cpp_util::get_required_str_param(this, "cca_robot");
+    const std::string joint_states_topic = ros_cpp_util::get_required_str_param(node_, "cca_joint_states_topic");
+    const std::string robot_name = ros_cpp_util::get_required_str_param(node_, "cca_robot");
 
     // Extract robot configuration and action-server names for various planning groups
-    planning_group_info_map_ = CcaRos::get_planning_group_info_map(this);
+    planning_group_info_map_ = CcaRos::get_planning_group_info_map(node_);
 
     // Initialize execution action clients for each planning group
     for (auto& [pg_name, pg_info] : planning_group_info_map_) {
@@ -26,12 +30,12 @@ CcaRos::CcaRos(const std::string &node_name, const rclcpp::NodeOptions &node_opt
     }
 
     // Initialize service/action clients and subscribers
-    val_and_viz_client_ = this->create_client<CcaRosValAndViz>(val_and_viz_ss_name_);
-    joint_states_sub_ = this->create_subscription<JointState>(
-        joint_states_topic,rclcpp::QoS(1000),std::bind(&CcaRos::joint_states_cb_, this, std::placeholders::_1));
+    val_and_viz_client_ = node_->create_client<CcaRosValAndViz>(val_and_viz_ss_name_);
+    joint_states_sub_ = node_->create_subscription<JointState>(
+        joint_states_topic,rclcpp::QoS(1000),std::bind(&CcaRos::joint_states_cb_, node_, std::placeholders::_1));
 
     // Setup TF buffer to task info lookup from TF tree
-    tf_buffer_   = std::make_unique<tf2_ros::Buffer>(this->get_clock());
+    tf_buffer_   = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
     RCLCPP_INFO(node_logger_, "Initialized %s node for %s", node_name.c_str(), robot_name.c_str());
@@ -548,21 +552,21 @@ cca_ros::ExecutionActionClients CcaRos::initialize_action_clients_(const cca_ros
     if (!ex_as_names.robot_and_gripper.empty())
     {
         ex_clients.robot_and_gripper =
-            rclcpp_action::create_client<FollowJointTrajectory>(this, ex_as_names.robot_and_gripper);
+            rclcpp_action::create_client<FollowJointTrajectory>(node_, ex_as_names.robot_and_gripper);
     }
 
     // If robot-only execution server is available, initialize it
     if (!ex_as_names.robot.empty())
     {
         ex_clients.robot =
-            rclcpp_action::create_client<FollowJointTrajectory>(this, ex_as_names.robot);
+            rclcpp_action::create_client<FollowJointTrajectory>(node_, ex_as_names.robot);
     }
 
     // If gripper-only execution server is available, initialize it
     if (!ex_as_names.gripper.empty())
     {
         ex_clients.gripper =
-            rclcpp_action::create_client<FollowJointTrajectory>(this, ex_as_names.gripper);
+            rclcpp_action::create_client<FollowJointTrajectory>(node_, ex_as_names.gripper);
     }
 
     return ex_clients;
@@ -699,7 +703,7 @@ KinematicState CcaRos::read_joint_states_()
     robot_joint_states_.positions.setConstant(std::numeric_limits<double>::quiet_NaN());
     gripper_joint_states_.positions.setConstant(std::numeric_limits<double>::quiet_NaN());
 
-    auto start_time = this->now();
+    auto start_time = node_->now();
     rclcpp::Rate loop_rate(10); // 10 Hz loop rate
 
     while (rclcpp::ok())
@@ -711,7 +715,7 @@ KinematicState CcaRos::read_joint_states_()
         }
 
         // Check for timeout
-        if ((this->now() - start_time) > rclcpp::Duration(joint_states_read_timeout_))
+        if ((node_->now() - start_time) > rclcpp::Duration(joint_states_read_timeout_))
         {
             throw std::runtime_error("Failed to read robot or gripper joint states within timeout.");
         }

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -18,11 +18,11 @@ CcaRos::CcaRos(std::shared_ptr<rclcpp::Node> node)
 {
 
     // --- Required params (throw if absent) ---
-    const std::string joint_states_topic = ros_cpp_util::get_required_str_param(node_, "cca_joint_states_topic");
-    const std::string robot_name = ros_cpp_util::get_required_str_param(node_, "cca_robot");
+    const std::string joint_states_topic = ros_cpp_util::get_required_str_param(node_.get(), "cca_joint_states_topic");
+    const std::string robot_name = ros_cpp_util::get_required_str_param(node_.get(), "cca_robot");
 
     // Extract robot configuration and action-server names for various planning groups
-    planning_group_info_map_ = CcaRos::get_planning_group_info_map(node_);
+    planning_group_info_map_ = CcaRos::get_planning_group_info_map(node_.get());
 
     // Initialize execution action clients for each planning group
     for (auto& [pg_name, pg_info] : planning_group_info_map_) {
@@ -32,13 +32,13 @@ CcaRos::CcaRos(std::shared_ptr<rclcpp::Node> node)
     // Initialize service/action clients and subscribers
     val_and_viz_client_ = node_->create_client<CcaRosValAndViz>(val_and_viz_ss_name_);
     joint_states_sub_ = node_->create_subscription<JointState>(
-        joint_states_topic,rclcpp::QoS(1000),std::bind(&CcaRos::joint_states_cb_, node_, std::placeholders::_1));
+        joint_states_topic,rclcpp::QoS(1000),std::bind(&CcaRos::joint_states_cb_, this, std::placeholders::_1));
 
     // Setup TF buffer to task info lookup from TF tree
     tf_buffer_   = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
-    RCLCPP_INFO(node_logger_, "Initialized %s node for %s", node_name.c_str(), robot_name.c_str());
+    RCLCPP_INFO(node_logger_, "Initialized %s node for %s", node_->get_name(), robot_name.c_str());
 }
 
 // Destructor for CcaRos, cleans up.

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -6,15 +6,8 @@
 namespace cca_ros
 {
 
-CcaRos::CcaRos(const std::string &node_name, const rclcpp::NodeOptions &node_options)
-    : CcaRos(std::make_shared<rclcpp::Node>(node_name, node_options))
-{}
-
-// Constructor for CcaRos, initializes the node and sets up required parameters and clients.
-CcaRos::CcaRos(std::shared_ptr<rclcpp::Node> node)
-    : node_(node),
-      node_logger_(node->get_logger()),   // Logger for the node
-      val_and_viz_ss_name_("/cca_ros_val_and_viz") // Validation and visualization service name
+CcaRosContext::CcaRosContext(std::shared_ptr<rclcpp::Node> node)
+    : node_(node)
 {
 
     // --- Required params (throw if absent) ---
@@ -24,21 +17,47 @@ CcaRos::CcaRos(std::shared_ptr<rclcpp::Node> node)
     // Extract robot configuration and action-server names for various planning groups
     planning_group_info_map_ = CcaRos::get_planning_group_info_map(node_.get());
 
-    // Initialize execution action clients for each planning group
-    for (auto& [pg_name, pg_info] : planning_group_info_map_) {
-          pg_info.ex_clients = this->initialize_action_clients_(pg_info.ex_as_names);
-    }
-
     // Initialize service/action clients and subscribers
-    val_and_viz_client_ = node_->create_client<CcaRosValAndViz>(val_and_viz_ss_name_);
     joint_states_sub_ = node_->create_subscription<JointState>(
-        joint_states_topic,rclcpp::QoS(1000),std::bind(&CcaRos::joint_states_cb_, this, std::placeholders::_1));
+        joint_states_topic, rclcpp::QoS(1000),std::bind(&CcaRosContext::joint_states_cb_, this, std::placeholders::_1));
 
-    // Setup TF buffer to task info lookup from TF tree
+    // Setup TF buffer to lookup task info from TF tree
     tf_buffer_   = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
-    RCLCPP_INFO(node_logger_, "Initialized %s node for %s", node_->get_name(), robot_name.c_str());
+    RCLCPP_INFO(node_->get_logger(), "Initialized %s node for %s", node_->get_name(), robot_name.c_str());
+}
+
+// Callback for joint_states topic — stores the latest raw message for copy-on-read by planners.
+void CcaRosContext::joint_states_cb_(const JointState::SharedPtr msg)
+{
+    std::lock_guard<std::mutex> lock(joint_states_mutex_);
+    latest_joint_state_msg_ = msg;
+    joint_states_cv_.notify_all();
+}
+
+CcaRos::CcaRos(const std::string &node_name, const rclcpp::NodeOptions &node_options)
+    : CcaRos(std::make_shared<rclcpp::Node>(node_name, node_options))
+{}
+
+// Constructor for CcaRos from a node — creates context internally and exposes it via get_context().
+CcaRos::CcaRos(std::shared_ptr<rclcpp::Node> node)
+    : CcaRos(std::make_shared<CcaRosContext>(node))
+{}
+
+// Constructor for CcaRos from a shared context — initializes per-planner resources only.
+CcaRos::CcaRos(std::shared_ptr<CcaRosContext> context)
+    : context_(context),
+      node_logger_(context->node_->get_logger()),   // Logger for the node
+      val_and_viz_ss_name_("/cca_ros_val_and_viz") // Validation and visualization service name
+{
+    // Initialize per-planner execution action clients for each planning group
+    for (const auto& [pg_name, pg_info] : context_->planning_group_info_map_) {
+        ex_clients_map_[pg_name] = this->initialize_action_clients_(pg_info.ex_as_names);
+    }
+
+    // Initialize validation and visualization service client
+    val_and_viz_client_ = context_->node_->create_client<CcaRosValAndViz>(val_and_viz_ss_name_);
 }
 
 // Destructor for CcaRos, cleans up.
@@ -47,10 +66,12 @@ CcaRos::~CcaRos()
     // Stop status checking thread before other members begin destruction
     result_status_thread_.request_stop();
 
-    // Shutdown ROS
-    rclcpp::shutdown();
 }
 
+std::shared_ptr<CcaRosContext> CcaRos::get_context() const
+{
+    return context_;
+}
 
 cca_ros::PlanningResponse CcaRos::plan(const cca_ros::PlanningRequest &planning_request) {
     // Delegate to the multi-request planner with a single-element vector
@@ -81,7 +102,7 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
     // Determine robot config for this planning group
     planning_group_ = planning_requests.front().planning_group; // Current planning group
     const affordance_util::RobotConfig& robotConfig = 
-	planning_group_info_map_.at(planning_group_).robot_config;
+	context_->planning_group_info_map_.at(planning_group_).robot_config;
 
     robot_slist_ = robotConfig.Slist;                         // Robot screw axes
     M_ = robotConfig.M;                                       // Home configuration matrix
@@ -95,8 +116,8 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
     const bool execute_trajectory = first_req.execute_trajectory; // All requests have the same value due to validation
     const bool execute_partial_trajectory = first_req.execute_partial_trajectory; // All requests have the same value due to validation
     const std::chrono::seconds& execution_timeout = first_req.execution_timeout; // All requests have the same value due to validation
-    ex_as_names_ = planning_group_info_map_.at(first_req.planning_group).ex_as_names; // Need this for create_goal_msg_ as well as execute_
-    ex_clients_ = planning_group_info_map_.at(first_req.planning_group).ex_clients; // Might as well extract here too although only needed in execute_
+    ex_as_names_ = context_->planning_group_info_map_.at(first_req.planning_group).ex_as_names; // Need this for create_goal_msg_ as well as execute_
+    ex_clients_ = ex_clients_map_.at(first_req.planning_group); // Might as well extract here too although only needed in execute_
 
     // Prepare to collect task descriptions for visualization. We don't directly use task descriptions from planning requests since 
     // sometimes the info is asked to be looked up later using different methods. 
@@ -185,7 +206,7 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
             try {
                 // Lookup transform from ref_frame_ to the lookup frame
                 const geometry_msgs::msg::TransformStamped transform_stamped = 
-                    tf_buffer_->lookupTransform(
+                    context_->tf_buffer_->lookupTransform(
                         ref_frame_, 
                         task_description.affordance_info_from.frame_name,
                         tf2::TimePointZero,  // Get latest available transform
@@ -225,7 +246,7 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
             try {
                 // Lookup transform from ref_frame_ to the lookup frame
                 const geometry_msgs::msg::TransformStamped transform_stamped = 
-                    tf_buffer_->lookupTransform(
+                    context_->tf_buffer_->lookupTransform(
                         ref_frame_, 
                         task_description.canonical_pose_from.frame_name,
                         tf2::TimePointZero,  // Get latest available transform
@@ -552,21 +573,21 @@ cca_ros::ExecutionActionClients CcaRos::initialize_action_clients_(const cca_ros
     if (!ex_as_names.robot_and_gripper.empty())
     {
         ex_clients.robot_and_gripper =
-            rclcpp_action::create_client<FollowJointTrajectory>(node_, ex_as_names.robot_and_gripper);
+            rclcpp_action::create_client<FollowJointTrajectory>(context_->node_, ex_as_names.robot_and_gripper);
     }
 
     // If robot-only execution server is available, initialize it
     if (!ex_as_names.robot.empty())
     {
         ex_clients.robot =
-            rclcpp_action::create_client<FollowJointTrajectory>(node_, ex_as_names.robot);
+            rclcpp_action::create_client<FollowJointTrajectory>(context_->node_, ex_as_names.robot);
     }
 
     // If gripper-only execution server is available, initialize it
     if (!ex_as_names.gripper.empty())
     {
         ex_clients.gripper =
-            rclcpp_action::create_client<FollowJointTrajectory>(node_, ex_as_names.gripper);
+            rclcpp_action::create_client<FollowJointTrajectory>(context_->node_, ex_as_names.gripper);
     }
 
     return ex_clients;
@@ -585,14 +606,14 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
 
     // Ensure planning group is valid
     std::string valid_pg_s;
-    for (const auto& [name, _] : planning_group_info_map_) {
+    for (const auto& [name, _] : context_->planning_group_info_map_) {
         if (!valid_pg_s.empty()){ 
 	    valid_pg_s += ", ";
 	}
         valid_pg_s += name;
     }
 
-    if (planning_group_info_map_.find(planning_group) == planning_group_info_map_.end()) {
+    if (context_->planning_group_info_map_.find(planning_group) == context_->planning_group_info_map_.end()) {
 	throw std::invalid_argument("Planning Request: Specified planning group '" + planning_group + "' is not valid. " + 
 				    "Possible options are: " + valid_pg_s);
     }
@@ -604,7 +625,7 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
     const bool execute_trajectory = reqs.front().execute_trajectory;
     const bool execute_partial_trajectory = reqs.front().execute_partial_trajectory;
     const std::chrono::seconds& execution_timeout = reqs.front().execution_timeout;
-    const ExecutionActionServerNames& ex_as_names = planning_group_info_map_.at(reqs.front().planning_group).ex_as_names;
+    const ExecutionActionServerNames& ex_as_names = context_->planning_group_info_map_.at(reqs.front().planning_group).ex_as_names;
     const bool robot_ex_as_exists = !ex_as_names.robot.empty();
     const bool gripper_ex_as_exists = !ex_as_names.gripper.empty() || !ex_as_names.robot_and_gripper.empty();
 
@@ -688,36 +709,32 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
     }
 }
 
-// Callback for joint_states topic.
-void CcaRos::joint_states_cb_(const JointState::SharedPtr msg)
-{
-    std::lock_guard<std::mutex> lock(joint_states_mutex_);
-    robot_joint_states_ = ros_cpp_util::get_ordered_joint_states(msg, robot_joint_names_);
-    gripper_joint_states_ = ros_cpp_util::get_ordered_joint_states(msg, gripper_joint_names_);
-    joint_states_cv_.notify_all();
-}
-
 // Retrieve robot joint states at the start of the affordance.
 KinematicState CcaRos::read_joint_states_()
 {
-    std::unique_lock<std::mutex> lock(joint_states_mutex_);
-    robot_joint_states_.positions.conservativeResize(robot_joint_names_.size());
-    gripper_joint_states_.positions.conservativeResize(gripper_joint_names_.size());
-    robot_joint_states_.positions.setConstant(std::numeric_limits<double>::quiet_NaN());
-    gripper_joint_states_.positions.setConstant(std::numeric_limits<double>::quiet_NaN());
-
-    if (!joint_states_cv_.wait_for(
-            lock,
-            std::chrono::duration<double>(joint_states_read_timeout_),
-            [&]() {
-                return !robot_joint_states_.positions.hasNaN() &&
-                       !gripper_joint_states_.positions.hasNaN();
-            }))
+    // Copy the latest raw message under the lock to minimize lock hold time
+    sensor_msgs::msg::JointState::SharedPtr msg_copy;
     {
+        std::unique_lock<std::mutex> lock(context_->joint_states_mutex_);
+        if (!context_->joint_states_cv_.wait_for(
+                lock,
+                std::chrono::duration<double>(joint_states_read_timeout_),
+                [&]() { return context_->latest_joint_state_msg_ != nullptr; }))
+        {
+            throw std::runtime_error("Failed to read robot or gripper joint states within timeout.");
+        }
+        msg_copy = context_->latest_joint_state_msg_; // Shallow copy of shared_ptr under lock
+    }
+
+    // Extract ordered joint states outside the lock
+    const ros_cpp_util::JointTrajPoint robot_js = ros_cpp_util::get_ordered_joint_states(msg_copy, robot_joint_names_);
+    const ros_cpp_util::JointTrajPoint gripper_js = ros_cpp_util::get_ordered_joint_states(msg_copy, gripper_joint_names_);
+
+    if (robot_js.positions.hasNaN() || gripper_js.positions.hasNaN()) {
         throw std::runtime_error("Failed to read robot or gripper joint states within timeout.");
     }
 
-    return KinematicState{robot_joint_states_.positions, gripper_joint_states_.positions[0]};
+    return KinematicState{robot_js.positions, gripper_js.positions[0]};
 }
 
 std::vector<geometry_msgs::msg::Pose> CcaRos::compute_cartesian_trajectory_(

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -28,6 +28,11 @@ CcaRosContext::CcaRosContext(std::shared_ptr<rclcpp::Node> node)
     RCLCPP_INFO(node_->get_logger(), "Initialized %s node for %s", node_->get_name(), robot_name.c_str());
 }
 
+const std::vector<std::string> &CcaRosContext::get_joint_names(const std::string &planning_group) const
+{
+    return planning_group_info_map_.at(planning_group).robot_config.joint_names.robot;
+}
+
 // Callback for joint_states topic — stores the latest raw message for copy-on-read by planners.
 void CcaRosContext::joint_states_cb_(const JointState::SharedPtr msg)
 {
@@ -71,6 +76,11 @@ CcaRos::~CcaRos()
 std::shared_ptr<CcaRosContext> CcaRos::get_context() const
 {
     return context_;
+}
+
+const std::vector<std::string> &CcaRos::get_joint_names(const std::string &planning_group) const
+{
+    return context_->get_joint_names(planning_group);
 }
 
 cca_ros::PlanningResponse CcaRos::plan(const cca_ros::PlanningRequest &planning_request) {

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -113,6 +113,7 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
 
     // Extract execution action server names and clients for this planning group
     const cca_ros::PlanningRequest& first_req = planning_requests.front();
+    const bool visualize_trajectory = first_req.visualize_trajectory; // All requests have the same value due to validation
     const bool execute_trajectory = first_req.execute_trajectory; // All requests have the same value due to validation
     const bool execute_partial_trajectory = first_req.execute_partial_trajectory; // All requests have the same value due to validation
     const std::chrono::seconds& execution_timeout = first_req.execution_timeout; // All requests have the same value due to validation
@@ -435,7 +436,7 @@ cca_ros::PlanningResponse CcaRos::plan(const std::vector<cca_ros::PlanningReques
     
     // Validate and visualize the complete trajectory
     auto validation_response = this->validate_and_visualize_(
-        final_goal_msg.robot, cartesian_trajectory, task_descriptions_for_val_and_viz);
+        final_goal_msg.robot, cartesian_trajectory, task_descriptions_for_val_and_viz, visualize_trajectory);
     
     if (validation_response->success) {
         RCLCPP_INFO(node_logger_, "%s validation service succeeded", val_and_viz_ss_name_.c_str());
@@ -622,6 +623,7 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
     const bool single_planning_request = reqs.size() == 1;
     const bool gripper_goal_specified = !std::isnan(reqs.front().task_description.goal.gripper);
     const bool robot_only_trajectory = !gripper_goal_specified;
+    const bool visualize_trajectory = reqs.front().visualize_trajectory;
     const bool execute_trajectory = reqs.front().execute_trajectory;
     const bool execute_partial_trajectory = reqs.front().execute_partial_trajectory;
     const std::chrono::seconds& execution_timeout = reqs.front().execution_timeout;
@@ -662,6 +664,12 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
             if (req.planning_group != planning_group) {
                 throw std::invalid_argument(
                     index_log + "Inconsistent planning group specification. All tasks must have the same planning group");
+            }
+
+            // Ensure all tasks either ask to visualize or don't
+            if (req.visualize_trajectory != visualize_trajectory) {
+                throw std::invalid_argument(
+                    index_log + "Inconsistent visualize trajectory specification. All tasks must either be visualized together or none of them.");
             }
 
             // Ensure all tasks either ask to execute or don't
@@ -818,7 +826,7 @@ cca_ros::GoalMsg CcaRos::create_goal_msg_(
 }
 
 // Validates and visualizes a given trajectory
-cca_ros_msgs::srv::CcaRosValAndViz::Response::SharedPtr CcaRos::validate_and_visualize_(const FollowJointTrajectoryGoal &goal, const std::vector<geometry_msgs::msg::Pose>& cartesian_trajectory, const std::vector<cc_affordance_planner::TaskDescription>& task_descriptions){
+cca_ros_msgs::srv::CcaRosValAndViz::Response::SharedPtr CcaRos::validate_and_visualize_(const FollowJointTrajectoryGoal &goal, const std::vector<geometry_msgs::msg::Pose>& cartesian_trajectory, const std::vector<cc_affordance_planner::TaskDescription>& task_descriptions, bool visualize_trajectory){
 
     // Create visualization request
     auto val_and_viz_serv_req = std::make_shared<CcaRosValAndViz::Request>();
@@ -826,6 +834,7 @@ cca_ros_msgs::srv::CcaRosValAndViz::Response::SharedPtr CcaRos::validate_and_vis
     val_and_viz_serv_req->joint_traj = goal.trajectory;
     val_and_viz_serv_req->cartesian_traj = cartesian_trajectory;
     val_and_viz_serv_req->ref_frame = ref_frame_;
+    val_and_viz_serv_req->visualize = visualize_trajectory;
 
     // Sentinel affordance reference pose (identity)
     geometry_msgs::msg::Pose aff_ref_pose_sentinel;

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -691,37 +691,30 @@ void CcaRos::validate_input_(const std::vector<cca_ros::PlanningRequest>& reqs)
 // Callback for joint_states topic.
 void CcaRos::joint_states_cb_(const JointState::SharedPtr msg)
 {
+    std::lock_guard<std::mutex> lock(joint_states_mutex_);
     robot_joint_states_ = ros_cpp_util::get_ordered_joint_states(msg, robot_joint_names_);
     gripper_joint_states_ = ros_cpp_util::get_ordered_joint_states(msg, gripper_joint_names_);
+    joint_states_cv_.notify_all();
 }
 
 // Retrieve robot joint states at the start of the affordance.
 KinematicState CcaRos::read_joint_states_()
 {
+    std::unique_lock<std::mutex> lock(joint_states_mutex_);
     robot_joint_states_.positions.conservativeResize(robot_joint_names_.size());
     gripper_joint_states_.positions.conservativeResize(gripper_joint_names_.size());
     robot_joint_states_.positions.setConstant(std::numeric_limits<double>::quiet_NaN());
     gripper_joint_states_.positions.setConstant(std::numeric_limits<double>::quiet_NaN());
 
-    auto start_time = node_->now();
-    rclcpp::Rate loop_rate(10); // 10 Hz loop rate
-
-    while (rclcpp::ok())
+    if (!joint_states_cv_.wait_for(
+            lock,
+            std::chrono::duration<double>(joint_states_read_timeout_),
+            [&]() {
+                return !robot_joint_states_.positions.hasNaN() &&
+                       !gripper_joint_states_.positions.hasNaN();
+            }))
     {
-        // Check joint states for NaN values
-        if (!robot_joint_states_.positions.hasNaN() && !gripper_joint_states_.positions.hasNaN())
-        {
-            break;
-        }
-
-        // Check for timeout
-        if ((node_->now() - start_time) > rclcpp::Duration(joint_states_read_timeout_))
-        {
-            throw std::runtime_error("Failed to read robot or gripper joint states within timeout.");
-        }
-
-        // Allow for callback processing and sleep
-        loop_rate.sleep();
+        throw std::runtime_error("Failed to read robot or gripper joint states within timeout.");
     }
 
     return KinematicState{robot_joint_states_.positions, gripper_joint_states_.positions[0]};

--- a/cca_ros/src/cca_ros/cca_ros.cpp
+++ b/cca_ros/src/cca_ros/cca_ros.cpp
@@ -33,6 +33,8 @@ const std::vector<std::string> &CcaRosContext::get_joint_names(const std::string
     return planning_group_info_map_.at(planning_group).robot_config.joint_names.robot;
 }
 
+std::shared_ptr<rclcpp::Node> CcaRosContext::get_node() const { return node_; }
+
 // Callback for joint_states topic — stores the latest raw message for copy-on-read by planners.
 void CcaRosContext::joint_states_cb_(const JointState::SharedPtr msg)
 {
@@ -64,6 +66,8 @@ CcaRos::CcaRos(std::shared_ptr<CcaRosContext> context)
     // Initialize validation and visualization service client
     val_and_viz_client_ = context_->node_->create_client<CcaRosValAndViz>(val_and_viz_ss_name_);
 }
+
+std::shared_ptr<rclcpp::Node> CcaRos::get_node() const { return context_->node_; }
 
 // Destructor for CcaRos, cleans up.
 CcaRos::~CcaRos()

--- a/cca_ros_action/include/cca_ros_action/cca_ros_action.hpp
+++ b/cca_ros_action/include/cca_ros_action/cca_ros_action.hpp
@@ -42,6 +42,7 @@ class CcaRosActionServer : public cca_ros::CcaRos
     explicit CcaRosActionServer(const std::string &node_name, const rclcpp::NodeOptions &node_options);
 
   private:
+    rclcpp::Logger node_logger_; ///< Logger 
     rclcpp_action::Server<CcaRosAction>::SharedPtr action_server_; ///< Action server to execute CCA ROS action
 
     static constexpr int TIMEOUT_SECS_ = 60; ///< Timeout in seconds before aborting the goal due to inactivity
@@ -106,6 +107,7 @@ class CcaRosActionClient : public rclcpp::Node
     void cancel_goal();
 
   private:
+    rclcpp::Logger node_logger_; ///< Logger 
     rclcpp_action::Client<CcaRosAction>::SharedPtr
         action_client_; ///< Client for sending goals to the CCA ROS action server
     std::shared_future<GoalHandleCcaRosActionClient::SharedPtr> goal_future_; ///< Future representing the goal handle

--- a/cca_ros_action/src/cca_ros_action/cca_ros_action.cpp
+++ b/cca_ros_action/src/cca_ros_action/cca_ros_action.cpp
@@ -3,22 +3,22 @@
 namespace cca_ros_action
 {
 CcaRosActionServer::CcaRosActionServer(const std::string &node_name, const rclcpp::NodeOptions &node_options)
-    : cca_ros::CcaRos(node_name, node_options)
+    : cca_ros::CcaRos(node_name, node_options), node_logger_(this->get_node()->get_logger())
 {
     // Initialize the action server
     action_server_ = rclcpp_action::create_server<CcaRosAction>(
-        this, CCA_ROS_AS_NAME,
+        this->get_node(), CCA_ROS_AS_NAME,
         std::bind(&CcaRosActionServer::handle_goal, this, std::placeholders::_1, std::placeholders::_2),
         std::bind(&CcaRosActionServer::handle_cancel, this, std::placeholders::_1),
         std::bind(&CcaRosActionServer::handle_accepted, this, std::placeholders::_1));
 
-    RCLCPP_INFO(this->get_logger(), "Action server '%s' initialized.", CCA_ROS_AS_NAME);
+    RCLCPP_INFO(node_logger_, "Action server '%s' initialized.", CCA_ROS_AS_NAME);
 }
 
 rclcpp_action::GoalResponse CcaRosActionServer::handle_goal(const rclcpp_action::GoalUUID &uuid,
                                                             std::shared_ptr<const CcaRosAction::Goal> goal)
 {
-    RCLCPP_INFO(this->get_logger(), "Received a new goal request on action server '%s' with affordance goal: %.4f.",
+    RCLCPP_INFO(node_logger_, "Received a new goal request on action server '%s' with affordance goal: %.4f.",
                 CCA_ROS_AS_NAME, goal->req.task_description.goal.affordance);
     (void)uuid;
 
@@ -29,7 +29,7 @@ rclcpp_action::GoalResponse CcaRosActionServer::handle_goal(const rclcpp_action:
 rclcpp_action::CancelResponse CcaRosActionServer::handle_cancel(
     const std::shared_ptr<GoalHandleCcaRosActionServer> goal_handle)
 {
-    RCLCPP_INFO(this->get_logger(), "Received a cancel request on action server '%s'.", CCA_ROS_AS_NAME);
+    RCLCPP_INFO(node_logger_, "Received a cancel request on action server '%s'.", CCA_ROS_AS_NAME);
     (void)goal_handle;
 
     this->cancel_execution();
@@ -38,7 +38,7 @@ rclcpp_action::CancelResponse CcaRosActionServer::handle_cancel(
 
 void CcaRosActionServer::handle_accepted(const std::shared_ptr<GoalHandleCcaRosActionServer> goal_handle)
 {
-    RCLCPP_INFO(this->get_logger(), "Accepted goal on action server '%s'.", CCA_ROS_AS_NAME);
+    RCLCPP_INFO(node_logger_, "Accepted goal on action server '%s'.", CCA_ROS_AS_NAME);
 
     // Safely launch the execution in a background thread
     std::thread([this, goal_handle]() {
@@ -50,19 +50,19 @@ void CcaRosActionServer::execute_action(const std::shared_ptr<GoalHandleCcaRosAc
 {
     const auto goal = goal_handle->get_goal();
 
-    RCLCPP_INFO(this->get_logger(), "Executing action on server '%s'.", CCA_ROS_AS_NAME);
+    RCLCPP_INFO(node_logger_, "Executing action on server '%s'.", CCA_ROS_AS_NAME);
 
     // Convert the ROS message to cca_ros planning request struct
     cca_ros::PlanningRequest req = cca_ros_util::convert_cca_ros_action_to_req(goal->req);
 
     // Print the log
     const std::stringstream req_log = cca_ros_util::log_cca_planning_request(req);
-    RCLCPP_INFO(this->get_logger(), "%s", req_log.str().c_str());
+    RCLCPP_INFO(node_logger_, "%s", req_log.str().c_str());
     
     const cca_ros::PlanningResponse response = this->plan(req);
     if (!response.result.success)
     {
-        RCLCPP_ERROR(this->get_logger(), "Execution failed on action server '%s'.", CCA_ROS_AS_NAME);
+        RCLCPP_ERROR(node_logger_, "Execution failed on action server '%s'.", CCA_ROS_AS_NAME);
         goal_handle->abort(std::make_shared<CcaRosAction::Result>());
         return;
     }
@@ -74,7 +74,7 @@ void CcaRosActionServer::execute_action(const std::shared_ptr<GoalHandleCcaRosAc
         auto current_time = std::chrono::steady_clock::now();
         if (std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time).count() > TIMEOUT_SECS_)
         {
-            RCLCPP_ERROR(this->get_logger(), "Timed out waiting for action request to complete on server '%s'.",
+            RCLCPP_ERROR(node_logger_, "Timed out waiting for action request to complete on server '%s'.",
                          CCA_ROS_AS_NAME);
             goal_handle->abort(std::make_shared<CcaRosAction::Result>());
             return;
@@ -82,13 +82,13 @@ void CcaRosActionServer::execute_action(const std::shared_ptr<GoalHandleCcaRosAc
 
         if (*response.status == cca_ros::Status::SUCCEEDED)
         {
-            RCLCPP_INFO(this->get_logger(), "Action successfully completed on server '%s'.", CCA_ROS_AS_NAME);
+            RCLCPP_INFO(node_logger_, "Action successfully completed on server '%s'.", CCA_ROS_AS_NAME);
             goal_handle->succeed(std::make_shared<CcaRosAction::Result>());
             return;
         }
         else if (*response.status == cca_ros::Status::UNKNOWN)
         {
-            RCLCPP_ERROR(this->get_logger(), "Action was interrupted mid-execution on server '%s'.", CCA_ROS_AS_NAME);
+            RCLCPP_ERROR(node_logger_, "Action was interrupted mid-execution on server '%s'.", CCA_ROS_AS_NAME);
             goal_handle->abort(std::make_shared<CcaRosAction::Result>());
             return;
         }
@@ -97,10 +97,11 @@ void CcaRosActionServer::execute_action(const std::shared_ptr<GoalHandleCcaRosAc
     }
 }
 
-CcaRosActionClient::CcaRosActionClient() : rclcpp::Node("cca_ros_action_client")
+CcaRosActionClient::CcaRosActionClient() : rclcpp::Node("cca_ros_action_client"), node_logger_(this->get_logger())
 {
 
     action_client_ = rclcpp_action::create_client<CcaRosAction>(this, CCA_ROS_AS_NAME);
+
 }
 void CcaRosActionClient::send_goal(const cca_ros::PlanningRequest &req)
 {
@@ -110,11 +111,11 @@ void CcaRosActionClient::send_goal(const cca_ros::PlanningRequest &req)
 
     if (!this->action_client_->wait_for_action_server())
     {
-        RCLCPP_ERROR(this->get_logger(), "%s action server not available after waiting", CCA_ROS_AS_NAME);
+        RCLCPP_ERROR(node_logger_, "%s action server not available after waiting", CCA_ROS_AS_NAME);
         rclcpp::shutdown();
     }
 
-    RCLCPP_INFO(this->get_logger(), "Sending goal to %s action server.", CCA_ROS_AS_NAME);
+    RCLCPP_INFO(node_logger_, "Sending goal to %s action server.", CCA_ROS_AS_NAME);
 
     using namespace std::placeholders;
     auto send_goal_options = rclcpp_action::Client<CcaRosAction>::SendGoalOptions();
@@ -134,13 +135,13 @@ void CcaRosActionClient::cancel_goal()
         }
         else
         {
-            RCLCPP_WARN(this->get_logger(), "Cannot cancel goal because it was not accepted by the server: %s",
+            RCLCPP_WARN(node_logger_, "Cannot cancel goal because it was not accepted by the server: %s",
                         CCA_ROS_AS_NAME);
         }
     }
     else
     {
-        RCLCPP_WARN(this->get_logger(), "Unable to cancel %s server goal due to the goal future being invalid ",
+        RCLCPP_WARN(node_logger_, "Unable to cancel %s server goal due to the goal future being invalid ",
                     CCA_ROS_AS_NAME);
     }
 }
@@ -148,11 +149,11 @@ void CcaRosActionClient::goal_response_cb_(const GoalHandleCcaRosActionClient::S
 {
     if (!goal_handle)
     {
-        RCLCPP_ERROR(this->get_logger(), "Goal was rejected by action server, %s", CCA_ROS_AS_NAME);
+        RCLCPP_ERROR(node_logger_, "Goal was rejected by action server, %s", CCA_ROS_AS_NAME);
     }
     else
     {
-        RCLCPP_INFO(this->get_logger(), "Goal accepted by %s server, waiting for result", CCA_ROS_AS_NAME);
+        RCLCPP_INFO(node_logger_, "Goal accepted by %s server, waiting for result", CCA_ROS_AS_NAME);
     }
 }
 
@@ -163,13 +164,13 @@ void CcaRosActionClient::result_cb_(const GoalHandleCcaRosActionClient::WrappedR
     case rclcpp_action::ResultCode::SUCCEEDED:
         break;
     case rclcpp_action::ResultCode::ABORTED:
-        RCLCPP_ERROR(this->get_logger(), "Goal was aborted by %s server", CCA_ROS_AS_NAME);
+        RCLCPP_ERROR(node_logger_, "Goal was aborted by %s server", CCA_ROS_AS_NAME);
         return;
     case rclcpp_action::ResultCode::CANCELED:
-        RCLCPP_ERROR(this->get_logger(), "Goal was canceled by %s server", CCA_ROS_AS_NAME);
+        RCLCPP_ERROR(node_logger_, "Goal was canceled by %s server", CCA_ROS_AS_NAME);
         return;
     default:
-        RCLCPP_ERROR(this->get_logger(), "Unknown result code from %s server", CCA_ROS_AS_NAME);
+        RCLCPP_ERROR(node_logger_, "Unknown result code from %s server", CCA_ROS_AS_NAME);
         return;
     }
 }

--- a/cca_ros_action/src/cca_ros_action_node.cpp
+++ b/cca_ros_action/src/cca_ros_action_node.cpp
@@ -6,6 +6,6 @@ int main(int argc, char **argv)
     rclcpp::init(argc, argv);
     rclcpp::NodeOptions node_options;
     auto node = std::make_shared<cca_ros_action::CcaRosActionServer>("cca_ros_action", node_options);
-    rclcpp::spin(node);
+    rclcpp::spin(node->get_node());
     return 0;
 }

--- a/cca_ros_behavior/include/cca_ros_behavior/cca_ros_behavior.hpp
+++ b/cca_ros_behavior/include/cca_ros_behavior/cca_ros_behavior.hpp
@@ -12,8 +12,6 @@
 #include <behaviortree_cpp/action_node.h>
 #include <chrono>
 #include <string>
-#include <thread>
-#include <variant>
 
 namespace cca_ros_behavior
 {
@@ -32,10 +30,8 @@ class CcaRosAction : public BT::StatefulActionNode
      *
      * @param name The name of the action node.
      * @param config Configuration for the Behavior Tree node.
-     * @param node_options Node options for the ROS 2 node (default is empty).
      */
-    CcaRosAction(const std::string &name, const BT::NodeConfig &config,
-                 const rclcpp::NodeOptions &node_options = rclcpp::NodeOptions());
+    CcaRosAction(const std::string &name, const BT::NodeConfig &config);
 
     /**
      * @brief Returns the list of ports required by this action node.
@@ -71,7 +67,7 @@ class CcaRosAction : public BT::StatefulActionNode
     void onHalted() override;
 
   private:
-    std::shared_ptr<cca_ros::CcaRos> node_;                         /**< Node for ROS communication */
+    std::shared_ptr<cca_ros::CcaRos> cca_ros_;                         /**< Node for ROS communication */
     std::jthread spinner_thread_;                                    /**< Thread to spin the node. */
     std::shared_ptr<cca_ros::Status> status_{nullptr};              /**< To check the status of the CCA action. */
     std::chrono::time_point<std::chrono::steady_clock> start_time_; /**< To monitor the timeout. */

--- a/cca_ros_behavior/include/cca_ros_behavior/cca_ros_behavior.hpp
+++ b/cca_ros_behavior/include/cca_ros_behavior/cca_ros_behavior.hpp
@@ -68,6 +68,7 @@ class CcaRosAction : public BT::StatefulActionNode
 
   private:
     std::shared_ptr<cca_ros::CcaRos> cca_ros_;                         /**< Node for ROS communication */
+    std::shared_ptr<cca_ros::CcaRosContext> cca_ros_context_;                         /**< Node for ROS communication */
     std::jthread spinner_thread_;                                    /**< Thread to spin the node. */
     std::shared_ptr<cca_ros::Status> status_{nullptr};              /**< To check the status of the CCA action. */
     std::chrono::time_point<std::chrono::steady_clock> start_time_; /**< To monitor the timeout. */

--- a/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
+++ b/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
@@ -3,14 +3,9 @@
 
 namespace cca_ros_behavior
 {
-CcaRosAction::CcaRosAction(const std::string &name, const BT::NodeConfig &config,
-                           const rclcpp::NodeOptions &node_options)
+CcaRosAction::CcaRosAction(const std::string &name, const BT::NodeConfig &config)
     : BT::StatefulActionNode(name, config)
-{
-    // Spin this node in a separate thread to handle ROS communication
-    node_ = std::make_shared<cca_ros::CcaRos>(name, node_options);
-    spinner_thread_ = std::jthread([this]() { rclcpp::spin(node_); });
-}
+{}
 
 BT::PortsList CcaRosAction::providedPorts()
 {
@@ -22,6 +17,25 @@ BT::PortsList CcaRosAction::providedPorts()
 
 BT::NodeStatus CcaRosAction::onStart()
 {
+
+    // Use existing context from blackboard if already set by caller or another CcaRosAction node
+    if (!cca_ros_context_)
+    {
+        auto entry = config().blackboard->getAny("cca_ros_context");
+        if (entry && !entry->empty())
+        {
+            cca_ros_context_ = config().blackboard->get<std::shared_ptr<cca_ros::CcaRosContext>>("cca_ros_context");
+        }
+        else
+        {
+            auto ros_node = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+            cca_ros_context_ = std::make_shared<cca_ros::CcaRosContext>(ros_node);
+            config().blackboard->set("cca_ros_context", cca_ros_context_);
+        }
+
+        cca_ros_ = std::make_shared<cca_ros::CcaRos>(cca_ros_context_);
+    }
+
     // Define type aliases for readability
     using PlanningRequestPtr = std::shared_ptr<cca_ros::PlanningRequest>;
     using PlanningRequestsPtr = std::shared_ptr<std::vector<cca_ros::PlanningRequest>>;
@@ -44,12 +58,12 @@ BT::NodeStatus CcaRosAction::onStart()
     if (req.has_value())
     {
         timeout_ = req.value()->execution_timeout;
-        response = node_->plan(*req.value());
+        response = cca_ros_->plan(*req.value());
     }
     else // reqs.has_value()
     {
         timeout_ = reqs.value()->front().execution_timeout;
-        response = node_->plan(*reqs.value());
+        response = cca_ros_->plan(*reqs.value());
     }
 
     // Record start time to monitor timeout
@@ -77,24 +91,24 @@ BT::NodeStatus CcaRosAction::onRunning()
     auto current_time = std::chrono::steady_clock::now();
     if (std::chrono::duration_cast<std::chrono::seconds>(current_time - start_time_) > timeout_)
     {
-        RCLCPP_ERROR(node_->get_logger(), "Timed out waiting for CCA action request to complete.");
+        RCLCPP_ERROR(cca_ros_->get_node()->get_logger(), "Timed out waiting for CCA action request to complete.");
         return BT::NodeStatus::FAILURE;
     }
 
     // Check the status of the CCA action
     if (*status_ == cca_ros::Status::SUCCEEDED)
     {
-        RCLCPP_INFO(node_->get_logger(), "CCA action successfully completed");
+        RCLCPP_INFO(cca_ros_->get_node()->get_logger(), "CCA action successfully completed");
         return BT::NodeStatus::SUCCESS;
     }
     else if (*status_ == cca_ros::Status::FAILED)
     {
-        RCLCPP_ERROR(node_->get_logger(), "CCA action may have been canceled or aborted.");
+        RCLCPP_ERROR(cca_ros_->get_node()->get_logger(), "CCA action may have been canceled or aborted.");
         return BT::NodeStatus::FAILURE;
     }
     else if (*status_ == cca_ros::Status::UNKNOWN)
     {
-        RCLCPP_ERROR(node_->get_logger(), "CCA action was interrupted mid-execution.");
+        RCLCPP_ERROR(cca_ros_->get_node()->get_logger(), "CCA action was interrupted mid-execution.");
         return BT::NodeStatus::FAILURE;
     }
     else
@@ -106,6 +120,6 @@ BT::NodeStatus CcaRosAction::onRunning()
 void CcaRosAction::onHalted()
 {
     // Attempt to cancel trajectory execution if the action is halted
-    node_->cancel_execution();
+    cca_ros_->cancel_execution();
 }
 } // namespace cca_ros_behavior

--- a/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
+++ b/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
@@ -32,9 +32,10 @@ BT::NodeStatus CcaRosAction::onStart()
             cca_ros_context_ = std::make_shared<cca_ros::CcaRosContext>(ros_node);
             config().blackboard->set("cca_ros_context", cca_ros_context_);
         }
-
-        cca_ros_ = std::make_shared<cca_ros::CcaRos>(cca_ros_context_);
     }
+  
+    // Create fresh CcaRos per execution to avoid member variable races if used under a Parallel node
+    cca_ros_ = std::make_shared<cca_ros::CcaRos>(cca_ros_context_);
 
     // Define type aliases for readability
     using PlanningRequestPtr = std::shared_ptr<cca_ros::PlanningRequest>;

--- a/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
+++ b/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
@@ -21,8 +21,12 @@ BT::NodeStatus CcaRosAction::onStart()
     // Use existing context from blackboard if already set by caller or another CcaRosAction node
     if (!cca_ros_context_)
     {
-        auto entry = config().blackboard->getAnyLocked("cca_ros_context");
-        if (entry && !entry->empty())
+        const bool context_exists = [&]() {
+            auto entry = config().blackboard->getAnyLocked("cca_ros_context");
+            return entry && !entry->empty();
+        }(); // getAnyLocked holds a mutex lock on the blackboard entry, so we release it before accessing the value with get<> to avoid deadlocks
+
+        if (context_exists)
         {
             cca_ros_context_ = config().blackboard->get<std::shared_ptr<cca_ros::CcaRosContext>>("cca_ros_context");
         }

--- a/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
+++ b/cca_ros_behavior/src/cca_ros_behavior/cca_ros_behavior.cpp
@@ -21,7 +21,7 @@ BT::NodeStatus CcaRosAction::onStart()
     // Use existing context from blackboard if already set by caller or another CcaRosAction node
     if (!cca_ros_context_)
     {
-        auto entry = config().blackboard->getAny("cca_ros_context");
+        auto entry = config().blackboard->getAnyLocked("cca_ros_context");
         if (entry && !entry->empty())
         {
             cca_ros_context_ = config().blackboard->get<std::shared_ptr<cca_ros::CcaRosContext>>("cca_ros_context");

--- a/cca_ros_behavior_features/CMakeLists.txt
+++ b/cca_ros_behavior_features/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.8)
+project(cca_ros_behavior_features)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(cca_ros_behavior REQUIRED)
+find_package(cc_affordance_planner REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/cca_ros_behavior_features/CMakeLists.txt
+++ b/cca_ros_behavior_features/CMakeLists.txt
@@ -1,25 +1,49 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
+
 project(cca_ros_behavior_features)
+
+set(CMAKE_CXX_STANDARD 20)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# find dependencies
+# ROS packages
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(cca_ros_behavior REQUIRED)
-find_package(cc_affordance_planner REQUIRED)
+find_package(cca_ros_features REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+include_directories(
+  include
+  ${rclcpp_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME} SHARED
+  src/${PROJECT_NAME}/${PROJECT_NAME}.cpp
+)
+
+ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp PUBLIC geometry_msgs PUBLIC cca_ros_features)
+
+ament_export_dependencies(rclcpp cca_ros_features geometry_msgs)
+
+ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+install(
+  DIRECTORY include/${PROJECT_NAME}
+  DESTINATION include
+)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/cca_ros_behavior_features/CMakeLists.txt
+++ b/cca_ros_behavior_features/CMakeLists.txt
@@ -11,21 +11,25 @@ endif()
 # ROS packages
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
 find_package(cca_ros_features REQUIRED)
-find_package(geometry_msgs REQUIRED)
-
-include_directories(
-  include
-  ${rclcpp_INCLUDE_DIRS}
-)
 
 add_library(${PROJECT_NAME} SHARED
-  src/${PROJECT_NAME}/${PROJECT_NAME}.cpp
+  src/${PROJECT_NAME}/get_affordative_grasp_pose.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp PUBLIC geometry_msgs PUBLIC cca_ros_features)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
-ament_export_dependencies(rclcpp cca_ros_features geometry_msgs)
+ament_target_dependencies(${PROJECT_NAME} PUBLIC
+  rclcpp
+  behaviortree_cpp
+  cca_ros_features
+)
+
+ament_export_dependencies(rclcpp behaviortree_cpp cca_ros_features)
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 

--- a/cca_ros_behavior_features/include/cca_ros_behavior_features/get_affordative_grasp_pose.hpp
+++ b/cca_ros_behavior_features/include/cca_ros_behavior_features/get_affordative_grasp_pose.hpp
@@ -87,12 +87,10 @@ class GetAffordativeGraspPose : public BT::StatefulActionNode
 
   private:
     rclcpp::Node::SharedPtr node_; ///< ROS 2 node obtained from the blackboard key "node"
+    std::shared_ptr<cca_ros::CcaRosContext> cca_ros_context_; ///< Context for CCA ROS
     std::future<std::optional<geometry_msgs::msg::PoseStamped>> result_future_; ///< Async planning result
-
     static constexpr std::chrono::milliseconds timeout_{100}; ///< Maximum time to wait for any planning thread
-    static constexpr int arm_start_index_in_wbc_traj_ =
-        3; ///< Starting index of arm joints in the WBC trajectory (first three joints are for the base)
-    static constexpr int arm_num_joints_ = 6; ///< Number of arm joints
+    std::stop_source stop_source_; ///< Stop source to signal get_affordative_grasp_pose to halt
 };
 
 } // namespace cca_ros_behavior_features

--- a/cca_ros_behavior_features/include/cca_ros_behavior_features/get_affordative_grasp_pose.hpp
+++ b/cca_ros_behavior_features/include/cca_ros_behavior_features/get_affordative_grasp_pose.hpp
@@ -1,0 +1,90 @@
+#ifndef GET_AFFORDATIVE_GRASP_POSE_HPP
+#define GET_AFFORDATIVE_GRASP_POSE_HPP
+
+#include "rclcpp/rclcpp.hpp"
+#include <Eigen/Core>
+#include <affordance_util/affordance_util.hpp>
+#include <atomic>
+#include <behaviortree_cpp/action_node.h>
+#include <cc_affordance_planner/cc_affordance_planner.hpp>
+#include <cc_affordance_planner/cc_affordance_planner_interface.hpp>
+#include <cca_ros/cca_ros.hpp>
+#include <chrono>
+#include <condition_variable>
+#include <geometry_msgs/msg/pose_array.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <mutex>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <thread>
+#include <vector>
+#include <cca_ros_features/cca_ros_features.hpp>
+
+/**
+ * @brief Behavior Tree action node that finds the first affordative grasp pose
+ *        from a set of candidate grasp poses by planning in parallel.
+ *
+ * For each candidate grasp pose, a dedicated CcaRos planner is spawned in its
+ * own thread. Each thread attempts to plan a full grasp sequence consisting of:
+ *   1. A whole-body controller (WBC) approach
+ *   2. An arm approach
+ *   3. An arm grab
+ *
+ * The node returns the first affordative grasp pose, i.e. the first grasp pose for which all three plans succeed,
+ * or FAILURE if no candidate pose yields a valid plan.
+ *
+ * Notable assumptions: Both wbc and arm planning requests contain gripper goals
+ *
+ * @par BT Ports
+ * | Direction | Name                    | Type                                          | Description |
+ * |-----------|-------------------------|-----------------------------------------------|--------------------------------------------------|
+ * | Input     | wbc_approach_req        | std::shared_ptr<CcaRos::PlanningRequest>      | Planning request for the WBC
+ * approach motion     | | Input     | arm_approach_req        | std::shared_ptr<CcaRos::PlanningRequest>      |
+ * Planning request for the arm approach motion     | | Input     | arm_grab_req            |
+ * std::shared_ptr<CcaRos::PlanningRequest>      | Planning request for the arm grab motion         | | Input     |
+ * grasp_poses             | std::shared_ptr<geometry_msgs::msg::PoseArray>| Array of candidate grasp poses to evaluate
+ * | | Output    | affordative_grasp_pose  | std::shared_ptr<geometry_msgs::msg::PoseStamped> | First grasp pose for
+ * which all plans succeeded|
+ *
+ * @inherits BT::SyncActionNode
+ * @inherits rclcpp::Node
+ */
+namespace chair_manipulation
+{
+class GetAffordativeGraspPose : public BT::SyncActionNode, public rclcpp::Node
+{
+  public:
+    /**
+     * @brief Construct a GetAffordativeGraspPose node.
+     * @param name  The name of the node, used for both the BT node and the ROS 2 node.
+     * @param config BT node configuration containing the blackboard and port mappings.
+     */
+    GetAffordativeGraspPose(const std::string &name, const BT::NodeConfig &config);
+
+    /**
+     * @brief Returns the list of input and output ports for this BT node.
+     * @return BT::PortsList containing all declared ports.
+     */
+    static BT::PortsList providedPorts();
+
+    /**
+     * @brief Executes the node logic.
+     *
+     * Reads all input ports, spawns one planning thread per candidate grasp pose,
+     * and waits for the first successful full plan or for all threads to complete.
+     *
+     * @return BT::NodeStatus::SUCCESS if an affordative grasp pose is found.
+     * @return BT::NodeStatus::FAILURE if any input port is missing or no valid plan is found.
+     */
+    BT::NodeStatus tick() override;
+
+  private:
+    const std::chrono::milliseconds timeout_{
+        100}; ///< Maximum time to wait for planning threads to find an affordative grasp pose
+    static constexpr int arm_start_index_in_wbc_traj =
+        3; ///< Starting index of arm joints in the whole-body trajectory (first three are for the base)
+    static constexpr int arm_num_joints = 6; ///< Number of arm joints
+};
+
+} // namespace chair_manipulation
+
+#endif // GET_AFFORDATIVE_GRASP_POSE_HPP

--- a/cca_ros_behavior_features/include/cca_ros_behavior_features/get_affordative_grasp_pose.hpp
+++ b/cca_ros_behavior_features/include/cca_ros_behavior_features/get_affordative_grasp_pose.hpp
@@ -48,7 +48,7 @@
  * @inherits BT::SyncActionNode
  * @inherits rclcpp::Node
  */
-namespace chair_manipulation
+namespace cca_ros_behavior_features
 {
 class GetAffordativeGraspPose : public BT::SyncActionNode, public rclcpp::Node
 {
@@ -85,6 +85,6 @@ class GetAffordativeGraspPose : public BT::SyncActionNode, public rclcpp::Node
     static constexpr int arm_num_joints = 6; ///< Number of arm joints
 };
 
-} // namespace chair_manipulation
+} // namespace cca_ros_behavior_features
 
 #endif // GET_AFFORDATIVE_GRASP_POSE_HPP

--- a/cca_ros_behavior_features/include/cca_ros_behavior_features/get_affordative_grasp_pose.hpp
+++ b/cca_ros_behavior_features/include/cca_ros_behavior_features/get_affordative_grasp_pose.hpp
@@ -1,61 +1,58 @@
-#ifndef GET_AFFORDATIVE_GRASP_POSE_HPP
-#define GET_AFFORDATIVE_GRASP_POSE_HPP
+///////////////////////////////////////////////////////////////////////////////
+//      Title     : get_affordative_grasp_pose.hpp
+//      Project   : cca_ros_behavior_features
+//      Created   : 2026
+//      Author    : Crasun Jans
+///////////////////////////////////////////////////////////////////////////////
 
-#include "rclcpp/rclcpp.hpp"
-#include <Eigen/Core>
-#include <affordance_util/affordance_util.hpp>
-#include <atomic>
+#ifndef GET_AFFORDATIVE_GRASP_POSE_HPP_
+#define GET_AFFORDATIVE_GRASP_POSE_HPP_
+
 #include <behaviortree_cpp/action_node.h>
-#include <cc_affordance_planner/cc_affordance_planner.hpp>
-#include <cc_affordance_planner/cc_affordance_planner_interface.hpp>
 #include <cca_ros/cca_ros.hpp>
+#include <cca_ros_features/cca_ros_features.hpp>
 #include <chrono>
-#include <condition_variable>
+#include <future>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
-#include <mutex>
-#include <tf2_eigen/tf2_eigen.hpp>
-#include <thread>
-#include <vector>
-#include <cca_ros_features/cca_ros_features.hpp>
+#include <optional>
+#include <rclcpp/rclcpp.hpp>
+
+namespace cca_ros_behavior_features
+{
 
 /**
  * @brief Behavior Tree action node that finds the first affordative grasp pose
  *        from a set of candidate grasp poses by planning in parallel.
  *
  * For each candidate grasp pose, a dedicated CcaRos planner is spawned in its
- * own thread. Each thread attempts to plan a full grasp sequence consisting of:
+ * own thread and attempts to plan a full grasp sequence:
  *   1. A whole-body controller (WBC) approach
- *   2. An arm approach
+ *   2. An arm approach (seeded from the WBC end state)
  *   3. An arm grab
  *
- * The node returns the first affordative grasp pose, i.e. the first grasp pose for which all three plans succeed,
- * or FAILURE if no candidate pose yields a valid plan.
+ * The node returns the first affordative grasp pose — i.e. the first candidate
+ * for which all three plans succeed — or FAILURE if no candidate yields a valid
+ * plan within the timeout.
  *
- * Notable assumptions: Both wbc and arm planning requests contain gripper goals
+ * @note Both WBC and arm planning requests are assumed to contain gripper goals.
+ * @note The rclcpp::Node::SharedPtr is read from the blackboard key @c "node".
  *
  * @par BT Ports
- * | Direction | Name                    | Type                                          | Description |
- * |-----------|-------------------------|-----------------------------------------------|--------------------------------------------------|
- * | Input     | wbc_approach_req        | std::shared_ptr<CcaRos::PlanningRequest>      | Planning request for the WBC
- * approach motion     | | Input     | arm_approach_req        | std::shared_ptr<CcaRos::PlanningRequest>      |
- * Planning request for the arm approach motion     | | Input     | arm_grab_req            |
- * std::shared_ptr<CcaRos::PlanningRequest>      | Planning request for the arm grab motion         | | Input     |
- * grasp_poses             | std::shared_ptr<geometry_msgs::msg::PoseArray>| Array of candidate grasp poses to evaluate
- * | | Output    | affordative_grasp_pose  | std::shared_ptr<geometry_msgs::msg::PoseStamped> | First grasp pose for
- * which all plans succeeded|
- *
- * @inherits BT::SyncActionNode
- * @inherits rclcpp::Node
+ * | Direction | Name                   | Type                                             | Description                                      |
+ * |-----------|------------------------|--------------------------------------------------|--------------------------------------------------|
+ * | Input     | wbc_approach_req       | std::shared_ptr<cca_ros::PlanningRequest>        | Planning request for the WBC approach motion     |
+ * | Input     | arm_approach_req       | std::shared_ptr<cca_ros::PlanningRequest>        | Planning request for the arm approach motion     |
+ * | Input     | arm_grab_req           | std::shared_ptr<cca_ros::PlanningRequest>        | Planning request for the arm grab motion         |
+ * | Input     | grasp_poses            | std::shared_ptr<geometry_msgs::msg::PoseArray>   | Array of candidate grasp poses to evaluate       |
+ * | Output    | affordative_grasp_pose | std::shared_ptr<geometry_msgs::msg::PoseStamped> | First grasp pose for which all plans succeeded   |
  */
-namespace cca_ros_behavior_features
-{
-class GetAffordativeGraspPose : public BT::SyncActionNode, public rclcpp::Node
+class GetAffordativeGraspPose : public BT::StatefulActionNode
 {
   public:
     /**
      * @brief Construct a GetAffordativeGraspPose node.
-     * @param name  The name of the node, used for both the BT node and the ROS 2 node.
+     * @param name   Name of the BT node.
      * @param config BT node configuration containing the blackboard and port mappings.
      */
     GetAffordativeGraspPose(const std::string &name, const BT::NodeConfig &config);
@@ -67,24 +64,37 @@ class GetAffordativeGraspPose : public BT::SyncActionNode, public rclcpp::Node
     static BT::PortsList providedPorts();
 
     /**
-     * @brief Executes the node logic.
+     * @brief Reads input ports, validates them, and launches the parallel planning search asynchronously.
      *
-     * Reads all input ports, spawns one planning thread per candidate grasp pose,
-     * and waits for the first successful full plan or for all threads to complete.
-     *
-     * @return BT::NodeStatus::SUCCESS if an affordative grasp pose is found.
-     * @return BT::NodeStatus::FAILURE if any input port is missing or no valid plan is found.
+     * @throws BT::RuntimeError if any required input port is missing or invalid.
+     * @return BT::NodeStatus::RUNNING after launching the async planning task.
      */
-    BT::NodeStatus tick() override;
+    BT::NodeStatus onStart() override;
+
+    /**
+     * @brief Polls the async planning task for completion on each BT tick.
+     *
+     * @return BT::NodeStatus::RUNNING while planning is in progress.
+     * @return BT::NodeStatus::SUCCESS if an affordative grasp pose was found; sets the output port.
+     * @return BT::NodeStatus::FAILURE if no valid plan was found within the timeout.
+     */
+    BT::NodeStatus onRunning() override;
+
+    /**
+     * @brief Waits for the async planning task to finish before releasing resources.
+     */
+    void onHalted() override;
 
   private:
-    const std::chrono::milliseconds timeout_{
-        100}; ///< Maximum time to wait for planning threads to find an affordative grasp pose
-    static constexpr int arm_start_index_in_wbc_traj =
-        3; ///< Starting index of arm joints in the whole-body trajectory (first three are for the base)
-    static constexpr int arm_num_joints = 6; ///< Number of arm joints
+    rclcpp::Node::SharedPtr node_; ///< ROS 2 node obtained from the blackboard key "node"
+    std::future<std::optional<geometry_msgs::msg::PoseStamped>> result_future_; ///< Async planning result
+
+    static constexpr std::chrono::milliseconds timeout_{100}; ///< Maximum time to wait for any planning thread
+    static constexpr int arm_start_index_in_wbc_traj_ =
+        3; ///< Starting index of arm joints in the WBC trajectory (first three joints are for the base)
+    static constexpr int arm_num_joints_ = 6; ///< Number of arm joints
 };
 
 } // namespace cca_ros_behavior_features
 
-#endif // GET_AFFORDATIVE_GRASP_POSE_HPP
+#endif // GET_AFFORDATIVE_GRASP_POSE_HPP_

--- a/cca_ros_behavior_features/package.xml
+++ b/cca_ros_behavior_features/package.xml
@@ -3,13 +3,14 @@
 <package format="3">
   <name>cca_ros_behavior_features</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
+  <description>cca_ros_features functions wrapped as BehaviorTree.CPP nodes</description>
   <maintainer email="jpanthi@utexas.edu">cjans-admin</maintainer>
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>behaviortree_cpp</depend>
   <depend>cca_ros_features</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/cca_ros_behavior_features/package.xml
+++ b/cca_ros_behavior_features/package.xml
@@ -10,8 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>cca_ros_behavior</depend>
-  <depend>cc_affordance_planner</depend>
+  <depend>cca_ros_features</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/cca_ros_behavior_features/package.xml
+++ b/cca_ros_behavior_features/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>cca_ros_behavior_features</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="jpanthi@utexas.edu">cjans-admin</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>cca_ros_behavior</depend>
+  <depend>cc_affordance_planner</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
+++ b/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
@@ -1,0 +1,85 @@
+#include "cca_ros_behavior_features/get_affordative_grasp_pose.hpp"
+
+namespace cca_ros_behavior_features
+{
+GetAffordativeGraspPose::GetAffordativeGraspPose(const std::string &name, const BT::NodeConfig &config)
+    : BT::SyncActionNode(name, config), rclcpp::Node(name)
+{
+}
+
+BT::PortsList GetAffordativeGraspPose::providedPorts()
+{
+    return {BT::InputPort<std::shared_ptr<cca_ros::PlanningRequest>>("wbc_approach_req"),
+            BT::InputPort<std::shared_ptr<cca_ros::PlanningRequest>>("arm_approach_req"),
+            BT::InputPort<std::shared_ptr<cca_ros::PlanningRequest>>("arm_grab_req"),
+            BT::InputPort<std::shared_ptr<geometry_msgs::msg::PoseArray>>("grasp_poses"),
+            BT::OutputPort<std::shared_ptr<geometry_msgs::msg::PoseStamped>>("affordative_grasp_pose")};
+}
+
+BT::NodeStatus GetAffordativeGraspPose::tick()
+{
+    // Define type alias for readability
+    using ReqPtr = std::shared_ptr<cca_ros::PlanningRequest>;
+    using PoseArrayPtr = std::shared_ptr<geometry_msgs::msg::PoseArray>;
+
+    // Retrieve inputs
+    BT::Expected<ReqPtr> wbc_approach_req_exp = getInput<ReqPtr>("wbc_approach_req");
+    BT::Expected<ReqPtr> arm_approach_req_exp = getInput<ReqPtr>("arm_approach_req");
+    BT::Expected<ReqPtr> arm_grab_req_exp = getInput<ReqPtr>("arm_grab_req");
+    BT::Expected<PoseArrayPtr> grasp_poses_exp = getInput<PoseArrayPtr>("grasp_poses");
+
+    // Check inputs and log errors if any are missing
+    if (!wbc_approach_req_exp)
+    {
+        RCLCPP_ERROR(this->get_logger(), "Missing input: wbc_approach_req. Error: %s",
+                     wbc_approach_req_exp.error().c_str());
+        return BT::NodeStatus::FAILURE;
+    }
+    if (!arm_approach_req_exp)
+    {
+        RCLCPP_ERROR(this->get_logger(), "Missing input: arm_approach_req. Error: %s",
+                     arm_approach_req_exp.error().c_str());
+        return BT::NodeStatus::FAILURE;
+    }
+    if (!arm_grab_req_exp)
+    {
+        RCLCPP_ERROR(this->get_logger(), "Missing input: arm_grab_req. Error: %s", arm_grab_req_exp.error().c_str());
+        return BT::NodeStatus::FAILURE;
+    }
+    if (!grasp_poses_exp)
+    {
+        RCLCPP_ERROR(this->get_logger(), "Missing input: grasp_poses. Error: %s", grasp_poses_exp.error().c_str());
+        return BT::NodeStatus::FAILURE;
+    }
+
+    // Unpack inputs
+    ReqPtr wbc_approach_req_ptr = wbc_approach_req_exp.value();
+    ReqPtr arm_approach_req_ptr = arm_approach_req_exp.value();
+    ReqPtr arm_grab_req_ptr = arm_grab_req_exp.value();
+    PoseArrayPtr grasp_poses = grasp_poses_exp.value();
+
+    // Find affordative grasp pose
+    const auto result = cca_ros_features::getAffordativeGraspPose(
+        *wbc_approach_req_ptr,
+        *arm_approach_req_ptr,
+        *arm_grab_req_ptr,
+        *grasp_poses,
+        timeout_,
+        arm_start_index_in_wbc_traj,
+        arm_num_joints);
+
+    if (!result)
+    {
+        RCLCPP_ERROR(this->get_logger(), "No affordative grasp pose found");
+        return BT::NodeStatus::FAILURE;
+    }
+
+    // Stamp and set output
+    geometry_msgs::msg::PoseStamped affordative_grasp_pose_stamped = *result;
+    affordative_grasp_pose_stamped.header.stamp = this->now();
+    setOutput("affordative_grasp_pose",
+              std::make_shared<geometry_msgs::msg::PoseStamped>(affordative_grasp_pose_stamped));
+
+    return BT::NodeStatus::SUCCESS;
+}
+} // namespace cca_ros_behavior_features

--- a/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
+++ b/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
@@ -1,9 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+//      Title     : get_affordative_grasp_pose.cpp
+//      Project   : cca_ros_behavior_features
+//      Created   : 2026
+//      Author    : Crasun Jans
+///////////////////////////////////////////////////////////////////////////////
+
 #include "cca_ros_behavior_features/get_affordative_grasp_pose.hpp"
 
 namespace cca_ros_behavior_features
 {
+
 GetAffordativeGraspPose::GetAffordativeGraspPose(const std::string &name, const BT::NodeConfig &config)
-    : BT::SyncActionNode(name, config), rclcpp::Node(name)
+    : BT::StatefulActionNode(name, config)
 {
 }
 
@@ -16,70 +24,64 @@ BT::PortsList GetAffordativeGraspPose::providedPorts()
             BT::OutputPort<std::shared_ptr<geometry_msgs::msg::PoseStamped>>("affordative_grasp_pose")};
 }
 
-BT::NodeStatus GetAffordativeGraspPose::tick()
+BT::NodeStatus GetAffordativeGraspPose::onStart()
 {
-    // Define type alias for readability
+    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+
     using ReqPtr = std::shared_ptr<cca_ros::PlanningRequest>;
     using PoseArrayPtr = std::shared_ptr<geometry_msgs::msg::PoseArray>;
 
-    // Retrieve inputs
-    BT::Expected<ReqPtr> wbc_approach_req_exp = getInput<ReqPtr>("wbc_approach_req");
-    BT::Expected<ReqPtr> arm_approach_req_exp = getInput<ReqPtr>("arm_approach_req");
-    BT::Expected<ReqPtr> arm_grab_req_exp = getInput<ReqPtr>("arm_grab_req");
-    BT::Expected<PoseArrayPtr> grasp_poses_exp = getInput<PoseArrayPtr>("grasp_poses");
-
-    // Check inputs and log errors if any are missing
+    auto wbc_approach_req_exp = getInput<ReqPtr>("wbc_approach_req");
     if (!wbc_approach_req_exp)
-    {
-        RCLCPP_ERROR(this->get_logger(), "Missing input: wbc_approach_req. Error: %s",
-                     wbc_approach_req_exp.error().c_str());
-        return BT::NodeStatus::FAILURE;
-    }
+        throw BT::RuntimeError("Missing input [wbc_approach_req]: ", wbc_approach_req_exp.error());
+
+    auto arm_approach_req_exp = getInput<ReqPtr>("arm_approach_req");
     if (!arm_approach_req_exp)
-    {
-        RCLCPP_ERROR(this->get_logger(), "Missing input: arm_approach_req. Error: %s",
-                     arm_approach_req_exp.error().c_str());
-        return BT::NodeStatus::FAILURE;
-    }
+        throw BT::RuntimeError("Missing input [arm_approach_req]: ", arm_approach_req_exp.error());
+
+    auto arm_grab_req_exp = getInput<ReqPtr>("arm_grab_req");
     if (!arm_grab_req_exp)
-    {
-        RCLCPP_ERROR(this->get_logger(), "Missing input: arm_grab_req. Error: %s", arm_grab_req_exp.error().c_str());
-        return BT::NodeStatus::FAILURE;
-    }
+        throw BT::RuntimeError("Missing input [arm_grab_req]: ", arm_grab_req_exp.error());
+
+    auto grasp_poses_exp = getInput<PoseArrayPtr>("grasp_poses");
     if (!grasp_poses_exp)
-    {
-        RCLCPP_ERROR(this->get_logger(), "Missing input: grasp_poses. Error: %s", grasp_poses_exp.error().c_str());
-        return BT::NodeStatus::FAILURE;
-    }
+        throw BT::RuntimeError("Missing input [grasp_poses]: ", grasp_poses_exp.error());
 
-    // Unpack inputs
-    ReqPtr wbc_approach_req_ptr = wbc_approach_req_exp.value();
-    ReqPtr arm_approach_req_ptr = arm_approach_req_exp.value();
-    ReqPtr arm_grab_req_ptr = arm_grab_req_exp.value();
-    PoseArrayPtr grasp_poses = grasp_poses_exp.value();
+    auto wbc_req = wbc_approach_req_exp.value();
+    auto arm_req = arm_approach_req_exp.value();
+    auto grab_req = arm_grab_req_exp.value();
+    auto poses = grasp_poses_exp.value();
 
-    // Find affordative grasp pose
-    const auto result = cca_ros_features::getAffordativeGraspPose(
-        *wbc_approach_req_ptr,
-        *arm_approach_req_ptr,
-        *arm_grab_req_ptr,
-        *grasp_poses,
-        timeout_,
-        arm_start_index_in_wbc_traj,
-        arm_num_joints);
+    result_future_ = std::async(std::launch::async, [wbc_req, arm_req, grab_req, poses, this]() {
+        return cca_ros_features::getAffordativeGraspPose(*wbc_req, *arm_req, *grab_req, *poses, timeout_,
+                                                         arm_start_index_in_wbc_traj_, arm_num_joints_);
+    });
 
+    return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus GetAffordativeGraspPose::onRunning()
+{
+    if (result_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
+        return BT::NodeStatus::RUNNING;
+
+    const auto result = result_future_.get();
     if (!result)
     {
-        RCLCPP_ERROR(this->get_logger(), "No affordative grasp pose found");
+        RCLCPP_ERROR(node_->get_logger(), "No affordative grasp pose found");
         return BT::NodeStatus::FAILURE;
     }
 
-    // Stamp and set output
-    geometry_msgs::msg::PoseStamped affordative_grasp_pose_stamped = *result;
-    affordative_grasp_pose_stamped.header.stamp = this->now();
-    setOutput("affordative_grasp_pose",
-              std::make_shared<geometry_msgs::msg::PoseStamped>(affordative_grasp_pose_stamped));
-
+    geometry_msgs::msg::PoseStamped stamped = *result;
+    stamped.header.stamp = node_->now();
+    setOutput("affordative_grasp_pose", std::make_shared<geometry_msgs::msg::PoseStamped>(stamped));
     return BT::NodeStatus::SUCCESS;
 }
+
+void GetAffordativeGraspPose::onHalted()
+{
+    if (result_future_.valid())
+        result_future_.wait();
+}
+
 } // namespace cca_ros_behavior_features

--- a/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
+++ b/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
@@ -26,11 +26,16 @@ BT::PortsList GetAffordativeGraspPose::providedPorts()
 
 BT::NodeStatus GetAffordativeGraspPose::onStart()
 {
+    // Use existing context from blackboard if already set by caller or another GetAffordativeGraspPose node
     if (!cca_ros_context_)
     {
         node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
-        auto entry = config().blackboard->getAnyLocked("cca_ros_context");
-        if (entry && !entry->empty())
+        const bool context_exists = [&]() {
+            auto entry = config().blackboard->getAnyLocked("cca_ros_context");
+            return entry && !entry->empty();
+        }(); // getAnyLocked holds a mutex lock on the blackboard entry, so we release it before accessing the value with get<> to avoid deadlocks
+
+        if (context_exists)
         {
             cca_ros_context_ = config().blackboard->get<std::shared_ptr<cca_ros::CcaRosContext>>("cca_ros_context");
         }

--- a/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
+++ b/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
@@ -26,7 +26,13 @@ BT::PortsList GetAffordativeGraspPose::providedPorts()
 
 BT::NodeStatus GetAffordativeGraspPose::onStart()
 {
-    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+    if (!cca_ros_context_)
+    {
+        node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+        cca_ros_context_ = std::make_shared<cca_ros::CcaRosContext>(node_);
+    }
+
+    stop_source_ = std::stop_source{};
 
     using ReqPtr = std::shared_ptr<cca_ros::PlanningRequest>;
     using PoseArrayPtr = std::shared_ptr<geometry_msgs::msg::PoseArray>;
@@ -51,10 +57,11 @@ BT::NodeStatus GetAffordativeGraspPose::onStart()
     auto arm_req = arm_approach_req_exp.value();
     auto grab_req = arm_grab_req_exp.value();
     auto poses = grasp_poses_exp.value();
+    const auto approach_reqs = std::vector<cca_ros::PlanningRequest>{*wbc_req, *arm_req};
 
-    result_future_ = std::async(std::launch::async, [wbc_req, arm_req, grab_req, poses, this]() {
-        return cca_ros_features::getAffordativeGraspPose(*wbc_req, *arm_req, *grab_req, *poses, timeout_,
-                                                         arm_start_index_in_wbc_traj_, arm_num_joints_);
+    result_future_ = std::async(std::launch::async, [approach_reqs, grab_req, poses, this]() {
+        return cca_ros_features::get_affordative_grasp_pose(
+            cca_ros_context_, approach_reqs, *grab_req, *poses, timeout_, stop_source_.get_token());
     });
 
     return BT::NodeStatus::RUNNING;
@@ -80,6 +87,7 @@ BT::NodeStatus GetAffordativeGraspPose::onRunning()
 
 void GetAffordativeGraspPose::onHalted()
 {
+    stop_source_.request_stop();
     if (result_future_.valid())
         result_future_.wait();
 }

--- a/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
+++ b/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
@@ -29,7 +29,16 @@ BT::NodeStatus GetAffordativeGraspPose::onStart()
     if (!cca_ros_context_)
     {
         node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
-        cca_ros_context_ = std::make_shared<cca_ros::CcaRosContext>(node_);
+        auto entry = config().blackboard->getAny("cca_ros_context");
+        if (entry && !entry->empty())
+        {
+            cca_ros_context_ = config().blackboard->get<std::shared_ptr<cca_ros::CcaRosContext>>("cca_ros_context");
+        }
+        else
+        {
+            cca_ros_context_ = std::make_shared<cca_ros::CcaRosContext>(node_);
+            config().blackboard->set("cca_ros_context", cca_ros_context_);
+        }
     }
 
     stop_source_ = std::stop_source{};

--- a/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
+++ b/cca_ros_behavior_features/src/cca_ros_behavior_features/get_affordative_grasp_pose.cpp
@@ -29,7 +29,7 @@ BT::NodeStatus GetAffordativeGraspPose::onStart()
     if (!cca_ros_context_)
     {
         node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
-        auto entry = config().blackboard->getAny("cca_ros_context");
+        auto entry = config().blackboard->getAnyLocked("cca_ros_context");
         if (entry && !entry->empty())
         {
             cca_ros_context_ = config().blackboard->get<std::shared_ptr<cca_ros::CcaRosContext>>("cca_ros_context");

--- a/cca_ros_features/CMakeLists.txt
+++ b/cca_ros_features/CMakeLists.txt
@@ -1,26 +1,57 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
+
 project(cca_ros_features)
+
+set(CMAKE_CXX_STANDARD 20)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# find dependencies
+# ROS packages
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(cca_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_eigen REQUIRED)
 
+# Non-ROS packages
+find_package(Eigen3 REQUIRED)
+find_package(affordance_util REQUIRED)
+
+include_directories(
+  include
+  ${rclcpp_INCLUDE_DIRS}
+  ${Eigen3_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME} SHARED
+  src/${PROJECT_NAME}/${PROJECT_NAME}.cpp
+)
+
+ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp PUBLIC cca_ros PUBLIC geometry_msgs PUBLIC tf2_eigen)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC affordance_util::affordance_util PUBLIC Eigen3::Eigen)
+
+ament_export_dependencies(rclcpp cca_ros geometry_msgs tf2_eigen affordance_util Eigen3)
+
+ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+install(
+  DIRECTORY include/${PROJECT_NAME}
+  DESTINATION include
+)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/cca_ros_features/CMakeLists.txt
+++ b/cca_ros_features/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.8)
+project(cca_ros_features)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(cca_ros REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(tf2_eigen REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/cca_ros_features/CMakeLists.txt
+++ b/cca_ros_features/CMakeLists.txt
@@ -19,19 +19,26 @@ find_package(tf2_eigen REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(affordance_util REQUIRED)
 
-include_directories(
-  include
-  ${rclcpp_INCLUDE_DIRS}
-  ${Eigen3_INCLUDE_DIRS}
-)
-
 add_library(${PROJECT_NAME} SHARED
-  src/${PROJECT_NAME}/${PROJECT_NAME}.cpp
+  src/${PROJECT_NAME}.cpp
 )
 
-ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp PUBLIC cca_ros PUBLIC geometry_msgs PUBLIC tf2_eigen)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
-target_link_libraries(${PROJECT_NAME} PUBLIC affordance_util::affordance_util PUBLIC Eigen3::Eigen)
+ament_target_dependencies(${PROJECT_NAME} PUBLIC
+  rclcpp
+  cca_ros
+  geometry_msgs
+  tf2_eigen
+)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  affordance_util::affordance_util
+  Eigen3::Eigen
+)
 
 ament_export_dependencies(rclcpp cca_ros geometry_msgs tf2_eigen affordance_util Eigen3)
 

--- a/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
+++ b/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
@@ -9,6 +9,7 @@
 #define CCA_ROS_FEATURES_HPP_
 
 #include <cca_ros/cca_ros.hpp>
+#include <affordance_util/affordance_util.hpp>
 #include <chrono>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>

--- a/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
+++ b/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
@@ -42,7 +42,7 @@ bool is_plannable(
  *
  * Note: The caller is responsible for spinning the underlying ROS nodes.
  *
- * @param node ROS node used for logging.
+ * @param context Shared CcaRosContext used for ROS infrastructure (logging, TF, joint states).
  * @param approach_reqs Sequence of planning requests of type APPROACH, potentially spanning multiple planning groups.
  * @param grab_req Planning request for the grab motion.
  * @param grasp_poses Array of candidate grasp poses to evaluate.
@@ -50,7 +50,7 @@ bool is_plannable(
  * @return The first affordative grasp pose stamped, or std::nullopt if none found.
  */
 std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
-    std::shared_ptr<rclcpp::Node> node,
+    std::shared_ptr<cca_ros::CcaRosContext> context,
     const std::vector<cca_ros::PlanningRequest> &approach_reqs,
     const cca_ros::PlanningRequest &grab_req,
     const geometry_msgs::msg::PoseArray &grasp_poses,

--- a/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
+++ b/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
@@ -1,0 +1,47 @@
+///////////////////////////////////////////////////////////////////////////////
+//      Title     : cca_ros_features.hpp
+//      Project   : cca_ros_features
+//      Created   : 2026
+//      Author    : Crasun Jans
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CCA_ROS_FEATURES_HPP_
+#define CCA_ROS_FEATURES_HPP_
+
+#include <cca_ros/cca_ros.hpp>
+#include <chrono>
+#include <geometry_msgs/msg/pose_array.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <optional>
+
+namespace cca_ros_features
+{
+
+/**
+ * @brief Finds the first affordative grasp pose from a set of candidates by
+ * planning in parallel. For each candidate grasp pose, a dedicated CcaRos
+ * planner is spawned in its own thread and attempts to plan a full grasp
+ * sequence: a WBC approach, an arm approach (seeded from the WBC end state),
+ * and an arm grab.
+ *
+ * @param wbc_approach_req Planning request for the WBC approach motion.
+ * @param arm_approach_req Planning request for the arm approach motion.
+ * @param arm_grab_req Planning request for the arm grab motion.
+ * @param grasp_poses Array of candidate grasp poses to evaluate.
+ * @param timeout Maximum time to wait across all planning threads.
+ * @param arm_start_index_in_wbc_traj Starting index of arm joints in the WBC trajectory.
+ * @param arm_num_joints Number of arm joints.
+ * @return The first affordative grasp pose stamped, or std::nullopt if none found.
+ */
+std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
+    const cca_ros::PlanningRequest &wbc_approach_req,
+    const cca_ros::PlanningRequest &arm_approach_req,
+    const cca_ros::PlanningRequest &arm_grab_req,
+    const geometry_msgs::msg::PoseArray &grasp_poses,
+    std::chrono::milliseconds timeout,
+    int arm_start_index_in_wbc_traj,
+    int arm_num_joints);
+
+} // namespace cca_ros_features
+
+#endif // CCA_ROS_FEATURES_HPP_

--- a/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
+++ b/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
@@ -28,11 +28,12 @@ namespace cca_ros_features
  *
  * @param planner Shared pointer to the CcaRos planner.
  * @param requests Sequence of planning requests, potentially spanning multiple planning groups.
+ * @param stop_token Optional stop token to allow cooperative cancellation of planning. 
  * @return true if all segments planned successfully, false otherwise.
  */
 bool is_plannable(
     std::shared_ptr<cca_ros::CcaRos> planner,
-    const std::vector<cca_ros::PlanningRequest> &requests);
+    const std::vector<cca_ros::PlanningRequest> &requests, std::stop_token stop_token = std::stop_token{});
 
 /**
  * @brief Finds the first affordative grasp pose from a set of candidates by

--- a/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
+++ b/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
@@ -28,7 +28,7 @@ namespace cca_ros_features
  *
  * @param planner Shared pointer to the CcaRos planner.
  * @param requests Sequence of planning requests, potentially spanning multiple planning groups.
- * @param stop_token Optional stop token to allow cooperative cancellation of planning. 
+ * @param stop_token Optional stop token to allow early cancellation.
  * @return true if all segments planned successfully, false otherwise.
  */
 bool is_plannable(
@@ -48,6 +48,7 @@ bool is_plannable(
  * @param grab_req Planning request for the grab motion.
  * @param grasp_poses Array of candidate grasp poses to evaluate.
  * @param timeout Maximum time to wait across all planning threads.
+ * @param stop_token Optional stop token to allow early cancellation.
  * @return The first affordative grasp pose stamped, or std::nullopt if none found.
  */
 std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
@@ -55,7 +56,8 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     const std::vector<cca_ros::PlanningRequest> &approach_reqs,
     const cca_ros::PlanningRequest &grab_req,
     const geometry_msgs::msg::PoseArray &grasp_poses,
-    std::chrono::milliseconds timeout);
+    std::chrono::milliseconds timeout,
+    std::stop_token stop_token = std::stop_token{});
 
 } // namespace cca_ros_features
 

--- a/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
+++ b/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
@@ -8,42 +8,53 @@
 #ifndef CCA_ROS_FEATURES_HPP_
 #define CCA_ROS_FEATURES_HPP_
 
-#include <Eigen/Geometry>
-#include <affordance_util/affordance_util.hpp>
 #include <cca_ros/cca_ros.hpp>
 #include <chrono>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <optional>
-#include <tf2_eigen/tf2_eigen.hpp>
+#include <unordered_map>
 
 namespace cca_ros_features
 {
 
 /**
+ * @brief Plans a sequence of requests spanning multiple planning groups
+ * sequentially. Requests with the same consecutive planning group are batched
+ * into one plan() call. Start state is chained between segments using joint
+ * names from the previous segment's trajectory end point.
+ *
+ * Note: The caller is responsible for spinning the underlying ROS node.
+ *
+ * @param planner Shared pointer to the CcaRos planner.
+ * @param requests Sequence of planning requests, potentially spanning multiple planning groups.
+ * @return true if all segments planned successfully, false otherwise.
+ */
+bool is_plannable(
+    std::shared_ptr<cca_ros::CcaRos> planner,
+    const std::vector<cca_ros::PlanningRequest> &requests);
+
+/**
  * @brief Finds the first affordative grasp pose from a set of candidates by
  * planning in parallel. For each candidate grasp pose, a dedicated CcaRos
- * planner is spawned in its own thread and attempts to plan a full grasp
- * sequence: a WBC approach, an arm approach (seeded from the WBC end state),
- * and an arm grab.
+ * planner is spawned in its own thread and attempts to plan a full sequence
+ * of approach requests followed by a grab request.
  *
- * @param wbc_approach_req Planning request for the WBC approach motion.
- * @param arm_approach_req Planning request for the arm approach motion.
- * @param arm_grab_req Planning request for the arm grab motion.
+ * Note: The caller is responsible for spinning the underlying ROS nodes.
+ *
+ * @param node ROS node used for logging.
+ * @param approach_reqs Sequence of planning requests of type APPROACH, potentially spanning multiple planning groups.
+ * @param grab_req Planning request for the grab motion.
  * @param grasp_poses Array of candidate grasp poses to evaluate.
  * @param timeout Maximum time to wait across all planning threads.
- * @param arm_start_index_in_wbc_traj Starting index of arm joints in the WBC trajectory.
- * @param arm_num_joints Number of arm joints.
  * @return The first affordative grasp pose stamped, or std::nullopt if none found.
  */
-std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
-    const cca_ros::PlanningRequest &wbc_approach_req,
-    const cca_ros::PlanningRequest &arm_approach_req,
-    const cca_ros::PlanningRequest &arm_grab_req,
+std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
+    std::shared_ptr<rclcpp::Node> node,
+    const std::vector<cca_ros::PlanningRequest> &approach_reqs,
+    const cca_ros::PlanningRequest &grab_req,
     const geometry_msgs::msg::PoseArray &grasp_poses,
-    std::chrono::milliseconds timeout,
-    int arm_start_index_in_wbc_traj,
-    int arm_num_joints);
+    std::chrono::milliseconds timeout);
 
 } // namespace cca_ros_features
 

--- a/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
+++ b/cca_ros_features/include/cca_ros_features/cca_ros_features.hpp
@@ -8,12 +8,14 @@
 #ifndef CCA_ROS_FEATURES_HPP_
 #define CCA_ROS_FEATURES_HPP_
 
-#include <cca_ros/cca_ros.hpp>
+#include <Eigen/Geometry>
 #include <affordance_util/affordance_util.hpp>
+#include <cca_ros/cca_ros.hpp>
 #include <chrono>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <optional>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 namespace cca_ros_features
 {

--- a/cca_ros_features/package.xml
+++ b/cca_ros_features/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>cca_ros_features</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
+  <description>Higher-level feature library built on cca_ros (e.g. getAffordativeGraspPose)</description>
   <maintainer email="jpanthi@utexas.edu">cjans-admin</maintainer>
   <license>TODO: License declaration</license>
 

--- a/cca_ros_features/package.xml
+++ b/cca_ros_features/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>cca_ros_features</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="jpanthi@utexas.edu">cjans-admin</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>cca_ros</depend>
+  <depend>geometry_msgs</depend>
+  <depend>tf2_eigen</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -1,0 +1,19 @@
+#include "cca_ros_features/cca_ros_features.hpp"
+
+namespace cca_ros_features
+{
+
+std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
+    const cca_ros::PlanningRequest &wbc_approach_req,
+    const cca_ros::PlanningRequest &arm_approach_req,
+    const cca_ros::PlanningRequest &arm_grab_req,
+    const geometry_msgs::msg::PoseArray &grasp_poses,
+    std::chrono::milliseconds timeout,
+    int arm_start_index_in_wbc_traj,
+    int arm_num_joints)
+{
+
+    return result;
+}
+
+} // namespace cca_ros_features

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -5,7 +5,7 @@ namespace cca_ros_features
 
 bool is_plannable(
     std::shared_ptr<cca_ros::CcaRos> planner,
-    const std::vector<cca_ros::PlanningRequest> &requests)
+    const std::vector<cca_ros::PlanningRequest> &requests, std::stop_token stop_token)
 {
     using PlanningSegment = std::vector<cca_ros::PlanningRequest>;
 
@@ -59,8 +59,14 @@ bool is_plannable(
                 extractStartState(prev_response, segment.front().planning_group);
         }
 
+	// Check for stop request before planning each segment
+	if (stop_token.stop_requested())
+	{
+	    return false;
+	}
+
         // Plan this segment
-        const auto response = planner->plan(segment);
+        const auto response = planner->plan(segment); // Note: plan() is blocking until a response is received. In the future, it may be desirable to have a plan_async() function in CcaRos that accepts a stop token, or have another mechanism to immediately interrupt. For now, since CCA planning is super quick anyways, this works for all practical purposes.
         if (!response.result.success)
         {
             return false;
@@ -78,12 +84,15 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     const geometry_msgs::msg::PoseArray &grasp_poses,
     std::chrono::milliseconds timeout)
 {
+
+    auto node_logger = context->get_node()->get_logger();
+
     // Verify approach_reqs are indeed approach types
     for (const auto &req : approach_reqs)
     {
         if (req.task_description.motion_type != cc_affordance_planner::MotionType::APPROACH)
         {
-            RCLCPP_ERROR(context->node_->get_logger(),
+            RCLCPP_ERROR(node_logger,
                 "All approach_reqs must have task_description.motion_type == cc_affordance_planner::MotionType::APPROACH");
             return std::nullopt;
         }
@@ -91,7 +100,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         if (req.task_description.canonical_pose_from.method != affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME ||
             req.task_description.affordance_info_from.method != affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME)
         {
-            RCLCPP_ERROR(context->node_->get_logger(),
+            RCLCPP_ERROR(node_logger,
                 "All approach_reqs must have task_description.canonical_pose_from and task_description.affordance_info_from set to method == FROM_FRAME_NAME");
             return std::nullopt;
         }
@@ -100,7 +109,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     // Verify grab_req is indeed an affordance type
     if (grab_req.task_description.motion_type != cc_affordance_planner::MotionType::AFFORDANCE)
     {
-        RCLCPP_ERROR(context->node_->get_logger(),
+        RCLCPP_ERROR(node_logger,
             "grab_req must have task_description.motion_type == cc_affordance_planner::MotionType::AFFORDANCE");
         return std::nullopt;
     }
@@ -108,7 +117,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     // Ensure grab req has affordance_info_from set to FROM_FRAME_NAME
     if (grab_req.task_description.affordance_info_from.method != affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME)
     {
-        RCLCPP_ERROR(context->node_->get_logger(),
+        RCLCPP_ERROR(node_logger,
             "grab_req must have task_description.affordance_info_from set to method == FROM_FRAME_NAME");
         return std::nullopt;
     }
@@ -116,7 +125,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     // Ensure affordance_info_from has axis_in_final_pose set
     if (grab_req.task_description.affordance_info_from.axis_in_final_pose.hasNaN())
     {
-        RCLCPP_ERROR(context->node_->get_logger(),
+        RCLCPP_ERROR(node_logger,
             "grab_req must have task_description.affordance_info_from.axis_in_final_pose set to a valid axis. Affordance axis is defined relative to the grasp pose.");
         return std::nullopt;
     }
@@ -181,7 +190,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         reqs.push_back(grab_req_l);
 
         // Check if these requests are plannable with this grasp pose
-        if (!is_plannable(planner, reqs) || stop_token.stop_requested())
+        if (!is_plannable(planner, reqs, stop_token))
         {
             std::lock_guard<std::mutex> lock(result_mutex);
             completed_threads++;

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -179,6 +179,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         {
             auto req_l = req;
             req_l.execute_trajectory = false;
+            req_l.execute_partial_trajectory = false;
             req_l.visualize_trajectory = false;
             req_l.task_description.affordance_info_from.frame_name = grasp_pose_frame_id;
             req_l.task_description.affordance_info_from.post_transform = grasp_pose_eigen.matrix();
@@ -190,6 +191,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         // Fill in affordance info for grab request (grab affordance is defined relative to the grasp pose)
         auto grab_req_l = grab_req;
         grab_req_l.execute_trajectory = false;
+        grab_req_l.execute_partial_trajectory = false;
         grab_req_l.visualize_trajectory = false;
         grab_req_l.task_description.affordance_info_from.frame_name = grasp_pose_frame_id;
         grab_req_l.task_description.affordance_info_from.post_transform = grasp_pose_eigen.matrix();

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -26,7 +26,7 @@ bool is_plannable(
     // Lambda to extract start state for the next segment from the previous segment's trajectory end point
     auto extractStartState = [&](const cca_ros::PlanningResponse &prev_response,
                                  const std::string &next_group) -> Eigen::VectorXd {
-        const std::vector<std::string> &next_joint_names = planner->getJointNames(next_group);
+        const std::vector<std::string> &next_joint_names = planner->get_joint_names(next_group);
         const auto &prev_traj = prev_response.result.joint_trajectory.trajectory;
         const auto &last_point = prev_traj.points.back();
 
@@ -72,7 +72,7 @@ bool is_plannable(
 }
 
 std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
-    std::shared_ptr<rclcpp::Node> node,
+    std::shared_ptr<cca_ros::CcaRosContext> context,
     const std::vector<cca_ros::PlanningRequest> &approach_reqs,
     const cca_ros::PlanningRequest &grab_req,
     const geometry_msgs::msg::PoseArray &grasp_poses,
@@ -83,7 +83,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     {
         if (req.task_description.motion_type != cc_affordance_planner::MotionType::APPROACH)
         {
-            RCLCPP_ERROR(node->get_logger(),
+            RCLCPP_ERROR(context->node_->get_logger(),
                 "All approach_reqs must have task_description.motion_type == cc_affordance_planner::MotionType::APPROACH");
             return std::nullopt;
         }
@@ -91,7 +91,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         if (req.task_description.canonical_pose_from.method != affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME ||
             req.task_description.affordance_info_from.method != affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME)
         {
-            RCLCPP_ERROR(node->get_logger(),
+            RCLCPP_ERROR(context->node_->get_logger(),
                 "All approach_reqs must have task_description.canonical_pose_from and task_description.affordance_info_from set to method == FROM_FRAME_NAME");
             return std::nullopt;
         }
@@ -100,7 +100,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     // Verify grab_req is indeed an affordance type
     if (grab_req.task_description.motion_type != cc_affordance_planner::MotionType::AFFORDANCE)
     {
-        RCLCPP_ERROR(node->get_logger(),
+        RCLCPP_ERROR(context->node_->get_logger(),
             "grab_req must have task_description.motion_type == cc_affordance_planner::MotionType::AFFORDANCE");
         return std::nullopt;
     }
@@ -108,7 +108,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     // Ensure grab req has affordance_info_from set to FROM_FRAME_NAME
     if (grab_req.task_description.affordance_info_from.method != affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME)
     {
-        RCLCPP_ERROR(node->get_logger(),
+        RCLCPP_ERROR(context->node_->get_logger(),
             "grab_req must have task_description.affordance_info_from set to method == FROM_FRAME_NAME");
         return std::nullopt;
     }
@@ -116,7 +116,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     // Ensure affordance_info_from has axis_in_final_pose set
     if (grab_req.task_description.affordance_info_from.axis_in_final_pose.hasNaN())
     {
-        RCLCPP_ERROR(node->get_logger(),
+        RCLCPP_ERROR(context->node_->get_logger(),
             "grab_req must have task_description.affordance_info_from.axis_in_final_pose set to a valid axis. Affordance axis is defined relative to the grasp pose.");
         return std::nullopt;
     }
@@ -131,12 +131,12 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     size_t completed_threads = 0;
     geometry_msgs::msg::Pose affordative_grasp_pose;
 
-    // Create a planner per grasp pose
+    // Create a planner per grasp pose, all sharing the same context
     using PlannerEntry = std::pair<geometry_msgs::msg::Pose, std::shared_ptr<cca_ros::CcaRos>>;
     std::vector<PlannerEntry> grasp_pose_to_planners;
     for (size_t i = 0; i < grasp_poses.poses.size(); ++i)
     {
-        auto planner = std::make_shared<cca_ros::CcaRos>(node);
+        auto planner = std::make_shared<cca_ros::CcaRos>(context);
         grasp_pose_to_planners.emplace_back(grasp_poses.poses[i], planner);
     }
 
@@ -164,6 +164,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         {
             auto req_l = req;
             req_l.execute_trajectory = false;
+            req_l.visualize_trajectory = false;
             req_l.task_description.affordance_info_from.frame_name = grasp_pose_frame_id;
             req_l.task_description.affordance_info_from.post_transform = grasp_pose_eigen.matrix();
             req_l.task_description.canonical_pose_from.frame_name = grasp_pose_frame_id;
@@ -174,6 +175,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         // Fill in affordance info for grab request (grab affordance is defined relative to the grasp pose)
         auto grab_req_l = grab_req;
         grab_req_l.execute_trajectory = false;
+        grab_req_l.visualize_trajectory = false;
         grab_req_l.task_description.affordance_info_from.frame_name = grasp_pose_frame_id;
         grab_req_l.task_description.affordance_info_from.post_transform = grasp_pose_eigen.matrix();
         reqs.push_back(grab_req_l);

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -1,3 +1,10 @@
+///////////////////////////////////////////////////////////////////////////////
+//      Title     : cca_ros_features.cpp
+//      Project   : cca_ros_features
+//      Created   : 2026
+//      Author    : Crasun Jans
+///////////////////////////////////////////////////////////////////////////////
+
 #include "cca_ros_features/cca_ros_features.hpp"
 
 namespace cca_ros_features
@@ -12,8 +19,7 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
     int arm_start_index_in_wbc_traj,
     int arm_num_joints)
 {
-
- // Set canonical_pose_from base for all planning requests
+    // Set canonical_pose_from base for all planning requests
     const std::string &grasp_pose_frame_id = grasp_poses.header.frame_id;
     affordance_util::PoseFrom canonical_pose_from_base;
     canonical_pose_from_base.method = affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME;

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -13,7 +13,151 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
     int arm_num_joints)
 {
 
-    return result;
+ // Set canonical_pose_from base for all planning requests
+    const std::string &grasp_pose_frame_id = grasp_poses->header.frame_id;
+    affordance_util::PoseFrom canonical_pose_from_base;
+    canonical_pose_from_base.method = affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME;
+    canonical_pose_from_base.frame_name = grasp_pose_frame_id;
+
+    // Set affordance_info_from base for all planning requests
+    affordance_util::ScrewInfoFrom affordance_info_from_base;
+    affordance_info_from_base.method = affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME;
+    affordance_info_from_base.frame_name = grasp_pose_frame_id;
+    affordance_info_from_base.axis_in_final_pose =
+        affordance_util::axis_to_vec(affordance_util::Axis::X_MINUS); // Along the outward-facing normal of the grasp
+
+    // Synchronization primitives for first-success detection
+    std::mutex result_mutex;
+    std::condition_variable result_cv;
+    bool found_successful_plan = false;
+    size_t completed_threads = 0;
+    geometry_msgs::msg::Pose affordative_grasp_pose;
+
+    // Create a planner per grasp pose
+    // NOTE: geometry_msgs::msg::Pose has no hash, so we use index-based storage
+    std::vector<std::pair<geometry_msgs::msg::Pose, std::shared_ptr<cca_ros::CcaRos>>> grasp_pose_to_planners;
+    for (size_t i = 0; i < grasp_poses->poses.size(); ++i)
+    {
+        auto planner = std::make_shared<cca_ros::CcaRos>("cca_ros_" + std::to_string(i), rclcpp::NodeOptions());
+        grasp_pose_to_planners.emplace_back(grasp_poses->poses[i], planner);
+    }
+
+    const size_t total_threads = grasp_pose_to_planners.size();
+
+    // Lambda to plan all requests for a given grasp pose and signal on first success
+    auto is_grasp_pose_affordative = [&](std::stop_token stop_token, std::shared_ptr<cca_ros::CcaRos> planner,
+                                         const geometry_msgs::msg::Pose &grasp_pose) {
+        // Check for stop request before starting expensive planning
+        if (stop_token.stop_requested())
+        {
+            std::lock_guard<std::mutex> lock(result_mutex);
+            completed_threads++;
+            result_cv.notify_one();
+            return;
+        }
+
+        // Convert pose to Eigen
+        Eigen::Isometry3d grasp_pose_eigen;
+        tf2::fromMsg(grasp_pose, grasp_pose_eigen);
+
+        // Set canonical pose info
+        affordance_util::PoseFrom canonical_pose_from = canonical_pose_from_base;
+        canonical_pose_from.post_transform = grasp_pose_eigen.matrix();
+
+        // Set affordance info
+        affordance_util::ScrewInfoFrom affordance_info_from = affordance_info_from_base;
+        affordance_info_from.post_transform = grasp_pose_eigen.matrix();
+
+        // Plan WBC approach
+        auto wbc_approach_req = *wbc_approach_req_ptr;
+        wbc_approach_req.execute_trajectory = false;
+        wbc_approach_req.task_description.affordance_info_from = affordance_info_from;
+        wbc_approach_req.task_description.canonical_pose_from = canonical_pose_from;
+        rclcpp::spin_some(planner); // We wanna read current state here
+        auto wbc_approach_response = planner->plan(wbc_approach_req);
+        if (!wbc_approach_response.result.success || stop_token.stop_requested())
+        {
+            std::lock_guard<std::mutex> lock(result_mutex);
+            completed_threads++;
+            result_cv.notify_one();
+            return;
+        }
+
+        // Update arm approach request, seeding start state from WBC result
+        auto arm_approach_req = *arm_approach_req_ptr;
+        arm_approach_req.execute_trajectory = false;
+        arm_approach_req.task_description.affordance_info_from = affordance_info_from;
+        arm_approach_req.task_description.canonical_pose_from = canonical_pose_from;
+        const Eigen::VectorXd &wbc_traj_end_point = wbc_approach_response.result.cca_result.joint_trajectory.back();
+        const Eigen::VectorXd &arm_start_state =
+            wbc_traj_end_point.segment(arm_start_index_in_wbc_traj, arm_num_joints);
+        const double gripper_start_state = wbc_traj_end_point(arm_start_index_in_wbc_traj + arm_num_joints);
+        arm_approach_req.start_state.robot = arm_start_state;
+        arm_approach_req.start_state.gripper = gripper_start_state;
+
+        // Disable execution for arm grab request
+        auto arm_grab_req = *arm_grab_req_ptr;
+        arm_grab_req.execute_trajectory = false;
+        arm_grab_req.task_description.affordance_info_from = affordance_info_from;
+
+        // Plan arm requests
+        std::vector<cca_ros::PlanningRequest> arm_reqs = {arm_approach_req, arm_grab_req};
+        auto arm_response = planner->plan(arm_reqs);
+        if (!arm_response.result.success || stop_token.stop_requested())
+        {
+            std::lock_guard<std::mutex> lock(result_mutex);
+            completed_threads++;
+            result_cv.notify_one();
+            return;
+        }
+
+        // Signal success via condition variable
+        {
+            std::lock_guard<std::mutex> lock(result_mutex);
+            if (!found_successful_plan)
+            { // Only set the first successful plan
+                found_successful_plan = true;
+                affordative_grasp_pose = grasp_pose;
+            }
+            completed_threads++;
+            result_cv.notify_one();
+        }
+    };
+
+    // Launch planning threads with stop tokens
+    std::vector<std::jthread> planning_threads;
+    for (const auto &[grasp_pose, planner] : grasp_pose_to_planners)
+    {
+        planning_threads.emplace_back([planner, grasp_pose, &is_grasp_pose_affordative](std::stop_token st) {
+            is_grasp_pose_affordative(st, planner, grasp_pose);
+        });
+    }
+
+    // Wait for first success, all threads to finish, or timeout
+    {
+        std::unique_lock<std::mutex> lock(result_mutex);
+        result_cv.wait_for(lock, timeout_,
+                           [&]() { return found_successful_plan || completed_threads == total_threads; });
+    }
+
+    // Request stop on all threads (no-op if already finished)
+    for (auto &t : planning_threads)
+    {
+        t.request_stop();
+    }
+
+    if (!found_successful_plan)
+    {
+        return std::nullopt; // No affordative grasp pose found within timeout
+    }
+
+    // Set output
+    geometry_msgs::msg::PoseStamped affordative_grasp_pose_stamped;
+    affordative_grasp_pose_stamped.pose = affordative_grasp_pose;
+    affordative_grasp_pose_stamped.header.stamp = grasp_poses.header.stamp;
+    affordative_grasp_pose_stamped.header.frame_id = grasp_pose_frame_id;
+
+    return affordative_grasp_pose_stamped;
 }
 
 } // namespace cca_ros_features

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -82,7 +82,8 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     const std::vector<cca_ros::PlanningRequest> &approach_reqs,
     const cca_ros::PlanningRequest &grab_req,
     const geometry_msgs::msg::PoseArray &grasp_poses,
-    std::chrono::milliseconds timeout)
+    std::chrono::milliseconds timeout,
+    std::stop_token stop_token)
 {
 
     auto node_logger = context->get_node()->get_logger();
@@ -130,6 +131,11 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         return std::nullopt;
     }
 
+    if (stop_token.stop_requested())
+    {
+        return std::nullopt;
+    }
+
     // Extract grasp pose frame id
     const std::string &grasp_pose_frame_id = grasp_poses.header.frame_id;
 
@@ -152,10 +158,10 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     const size_t total_threads = grasp_pose_to_planners.size();
 
     // Lambda to plan all requests for a given grasp pose and signal on first success
-    auto is_grasp_pose_affordative = [&](std::stop_token stop_token, std::shared_ptr<cca_ros::CcaRos> planner,
+    auto is_grasp_pose_affordative = [&](std::stop_token st, std::shared_ptr<cca_ros::CcaRos> planner,
                                          const geometry_msgs::msg::Pose &grasp_pose) {
         // Check for stop request before starting expensive planning
-        if (stop_token.stop_requested())
+        if (st.stop_requested())
         {
             std::lock_guard<std::mutex> lock(result_mutex);
             completed_threads++;
@@ -190,7 +196,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         reqs.push_back(grab_req_l);
 
         // Check if these requests are plannable with this grasp pose
-        if (!is_plannable(planner, reqs, stop_token))
+        if (!is_plannable(planner, reqs, st))
         {
             std::lock_guard<std::mutex> lock(result_mutex);
             completed_threads++;
@@ -215,8 +221,9 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     std::vector<std::jthread> planning_threads;
     for (const auto &[grasp_pose, planner] : grasp_pose_to_planners)
     {
-        planning_threads.emplace_back([planner, grasp_pose, &is_grasp_pose_affordative](std::stop_token st) {
-            is_grasp_pose_affordative(st, planner, grasp_pose);
+        planning_threads.emplace_back([planner, grasp_pose, &is_grasp_pose_affordative, stop_token](std::stop_token jthread_st) {
+            if (stop_token.stop_requested()){return;}
+            is_grasp_pose_affordative(jthread_st, planner, grasp_pose);
         });
     }
 
@@ -224,7 +231,7 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     {
         std::unique_lock<std::mutex> lock(result_mutex);
         result_cv.wait_for(lock, timeout,
-                           [&]() { return found_successful_plan || completed_threads == total_threads; });
+                           [&]() { return found_successful_plan || completed_threads == total_threads || stop_token.stop_requested(); });
     }
 
     // Request stop on all threads (no-op if already finished)

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -87,20 +87,42 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
                 "All approach_reqs must have task_description.motion_type == cc_affordance_planner::MotionType::APPROACH");
             return std::nullopt;
         }
+        // Ensure approach reqs have canonical_pose_from and affordance_info_from set to FROM_FRAME_NAME
+        if (req.task_description.canonical_pose_from.method != affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME ||
+            req.task_description.affordance_info_from.method != affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME)
+        {
+            RCLCPP_ERROR(node->get_logger(),
+                "All approach_reqs must have task_description.canonical_pose_from and task_description.affordance_info_from set to method == FROM_FRAME_NAME");
+            return std::nullopt;
+        }
     }
 
-    // Set canonical_pose_from base for all planning requests
-    const std::string &grasp_pose_frame_id = grasp_poses.header.frame_id;
-    affordance_util::PoseFrom canonical_pose_from_base;
-    canonical_pose_from_base.method = affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME;
-    canonical_pose_from_base.frame_name = grasp_pose_frame_id;
+    // Verify grab_req is indeed an affordance type
+    if (grab_req.task_description.motion_type != cc_affordance_planner::MotionType::AFFORDANCE)
+    {
+        RCLCPP_ERROR(node->get_logger(),
+            "grab_req must have task_description.motion_type == cc_affordance_planner::MotionType::AFFORDANCE");
+        return std::nullopt;
+    }
 
-    // Set affordance_info_from base for all planning requests
-    affordance_util::ScrewInfoFrom affordance_info_from_base;
-    affordance_info_from_base.method = affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME;
-    affordance_info_from_base.frame_name = grasp_pose_frame_id;
-    affordance_info_from_base.axis_in_final_pose =
-        affordance_util::axis_to_vec(affordance_util::Axis::X_MINUS); // Along the outward-facing normal of the grasp
+    // Ensure grab req has affordance_info_from set to FROM_FRAME_NAME
+    if (grab_req.task_description.affordance_info_from.method != affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME)
+    {
+        RCLCPP_ERROR(node->get_logger(),
+            "grab_req must have task_description.affordance_info_from set to method == FROM_FRAME_NAME");
+        return std::nullopt;
+    }
+
+    // Ensure affordance_info_from has axis_in_final_pose set
+    if (grab_req.task_description.affordance_info_from.axis_in_final_pose.hasNaN())
+    {
+        RCLCPP_ERROR(node->get_logger(),
+            "grab_req must have task_description.affordance_info_from.axis_in_final_pose set to a valid axis. Affordance axis is defined relative to the grasp pose.");
+        return std::nullopt;
+    }
+
+    // Extract grasp pose frame id
+    const std::string &grasp_pose_frame_id = grasp_poses.header.frame_id;
 
     // Synchronization primitives for first-success detection
     std::mutex result_mutex;
@@ -110,12 +132,11 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
     geometry_msgs::msg::Pose affordative_grasp_pose;
 
     // Create a planner per grasp pose
-    // NOTE: geometry_msgs::msg::Pose has no hash, so we use index-based storage
-    std::vector<std::pair<geometry_msgs::msg::Pose, std::shared_ptr<cca_ros::CcaRos>>> grasp_pose_to_planners;
+    using PlannerEntry = std::pair<geometry_msgs::msg::Pose, std::shared_ptr<cca_ros::CcaRos>>;
+    std::vector<PlannerEntry> grasp_pose_to_planners;
     for (size_t i = 0; i < grasp_poses.poses.size(); ++i)
     {
-        auto planner_node = std::make_shared<rclcpp::Node>("cca_ros_node_" + std::to_string(i));
-        auto planner = std::make_shared<cca_ros::CcaRos>(planner_node);
+        auto planner = std::make_shared<cca_ros::CcaRos>(node);
         grasp_pose_to_planners.emplace_back(grasp_poses.poses[i], planner);
     }
 
@@ -137,29 +158,24 @@ std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
         Eigen::Isometry3d grasp_pose_eigen;
         tf2::fromMsg(grasp_pose, grasp_pose_eigen);
 
-        // Set canonical pose info
-        affordance_util::PoseFrom canonical_pose_from = canonical_pose_from_base;
-        canonical_pose_from.post_transform = grasp_pose_eigen.matrix();
-
-        // Set affordance info -- affordance is defined relative to the grasp pose
-        affordance_util::ScrewInfoFrom affordance_info_from = affordance_info_from_base;
-        affordance_info_from.post_transform = grasp_pose_eigen.matrix();
-
         // Fill in grasp pose info for all approach requests
         std::vector<cca_ros::PlanningRequest> reqs;
         for (const auto &req : approach_reqs)
         {
             auto req_l = req;
             req_l.execute_trajectory = false;
-            req_l.task_description.affordance_info_from = affordance_info_from;
-            req_l.task_description.canonical_pose_from = canonical_pose_from;
+            req_l.task_description.affordance_info_from.frame_name = grasp_pose_frame_id;
+            req_l.task_description.affordance_info_from.post_transform = grasp_pose_eigen.matrix();
+            req_l.task_description.canonical_pose_from.frame_name = grasp_pose_frame_id;
+            req_l.task_description.canonical_pose_from.post_transform = grasp_pose_eigen.matrix();
             reqs.push_back(req_l);
         }
 
         // Fill in affordance info for grab request (grab affordance is defined relative to the grasp pose)
         auto grab_req_l = grab_req;
         grab_req_l.execute_trajectory = false;
-        grab_req_l.task_description.affordance_info_from = affordance_info_from;
+        grab_req_l.task_description.affordance_info_from.frame_name = grasp_pose_frame_id;
+        grab_req_l.task_description.affordance_info_from.post_transform = grasp_pose_eigen.matrix();
         reqs.push_back(grab_req_l);
 
         // Check if these requests are plannable with this grasp pose

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -1,24 +1,94 @@
-///////////////////////////////////////////////////////////////////////////////
-//      Title     : cca_ros_features.cpp
-//      Project   : cca_ros_features
-//      Created   : 2026
-//      Author    : Crasun Jans
-///////////////////////////////////////////////////////////////////////////////
-
 #include "cca_ros_features/cca_ros_features.hpp"
 
 namespace cca_ros_features
 {
 
-std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
-    const cca_ros::PlanningRequest &wbc_approach_req,
-    const cca_ros::PlanningRequest &arm_approach_req,
-    const cca_ros::PlanningRequest &arm_grab_req,
-    const geometry_msgs::msg::PoseArray &grasp_poses,
-    std::chrono::milliseconds timeout,
-    int arm_start_index_in_wbc_traj,
-    int arm_num_joints)
+bool is_plannable(
+    std::shared_ptr<cca_ros::CcaRos> planner,
+    const std::vector<cca_ros::PlanningRequest> &requests)
 {
+    using PlanningSegment = std::vector<cca_ros::PlanningRequest>;
+
+    // Segment requests by consecutive planning group
+    std::vector<PlanningSegment> segments;
+    for (const auto &req : requests)
+    {
+        if (segments.empty() || segments.back().front().planning_group != req.planning_group)
+        {
+            segments.push_back({req});
+        }
+        else
+        {
+            segments.back().push_back(req);
+        }
+    }
+
+    // Lambda to extract start state for the next segment from the previous segment's trajectory end point
+    auto extractStartState = [&](const cca_ros::PlanningResponse &prev_response,
+                                 const std::string &next_group) -> Eigen::VectorXd {
+        const std::vector<std::string> &next_joint_names = planner->getJointNames(next_group);
+        const auto &prev_traj = prev_response.result.joint_trajectory.trajectory;
+        const auto &last_point = prev_traj.points.back();
+
+        // Build name->position map from previous segment's end point
+        std::unordered_map<std::string, double> name_to_pos;
+        for (size_t i = 0; i < prev_traj.joint_names.size(); ++i)
+        {
+            name_to_pos[prev_traj.joint_names[i]] = last_point.positions[i];
+        }
+
+        // Extract positions in next group's joint order
+        Eigen::VectorXd start_state(next_joint_names.size());
+        for (size_t i = 0; i < next_joint_names.size(); ++i)
+        {
+            start_state[i] = name_to_pos.at(next_joint_names[i]);
+        }
+        return start_state;
+    };
+
+    cca_ros::PlanningResponse prev_response;
+
+    for (size_t seg_idx = 0; seg_idx < segments.size(); ++seg_idx)
+    {
+        auto &segment = segments[seg_idx];
+
+        // Chain start state from previous segment's trajectory end point
+        if (seg_idx > 0)
+        {
+            segment.front().start_state.robot =
+                extractStartState(prev_response, segment.front().planning_group);
+        }
+
+        // Plan this segment
+        const auto response = planner->plan(segment);
+        if (!response.result.success)
+        {
+            return false;
+        }
+        prev_response = response;
+    }
+
+    return true;
+}
+
+std::optional<geometry_msgs::msg::PoseStamped> get_affordative_grasp_pose(
+    std::shared_ptr<rclcpp::Node> node,
+    const std::vector<cca_ros::PlanningRequest> &approach_reqs,
+    const cca_ros::PlanningRequest &grab_req,
+    const geometry_msgs::msg::PoseArray &grasp_poses,
+    std::chrono::milliseconds timeout)
+{
+    // Verify approach_reqs are indeed approach types
+    for (const auto &req : approach_reqs)
+    {
+        if (req.task_description.motion_type != cc_affordance_planner::MotionType::APPROACH)
+        {
+            RCLCPP_ERROR(node->get_logger(),
+                "All approach_reqs must have task_description.motion_type == cc_affordance_planner::MotionType::APPROACH");
+            return std::nullopt;
+        }
+    }
+
     // Set canonical_pose_from base for all planning requests
     const std::string &grasp_pose_frame_id = grasp_poses.header.frame_id;
     affordance_util::PoseFrom canonical_pose_from_base;
@@ -44,7 +114,8 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
     std::vector<std::pair<geometry_msgs::msg::Pose, std::shared_ptr<cca_ros::CcaRos>>> grasp_pose_to_planners;
     for (size_t i = 0; i < grasp_poses.poses.size(); ++i)
     {
-        auto planner = std::make_shared<cca_ros::CcaRos>("cca_ros_" + std::to_string(i), rclcpp::NodeOptions());
+        auto planner_node = std::make_shared<rclcpp::Node>("cca_ros_node_" + std::to_string(i));
+        auto planner = std::make_shared<cca_ros::CcaRos>(planner_node);
         grasp_pose_to_planners.emplace_back(grasp_poses.poses[i], planner);
     }
 
@@ -70,46 +141,29 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
         affordance_util::PoseFrom canonical_pose_from = canonical_pose_from_base;
         canonical_pose_from.post_transform = grasp_pose_eigen.matrix();
 
-        // Set affordance info
+        // Set affordance info -- affordance is defined relative to the grasp pose
         affordance_util::ScrewInfoFrom affordance_info_from = affordance_info_from_base;
         affordance_info_from.post_transform = grasp_pose_eigen.matrix();
 
-        // Plan WBC approach
-        auto wbc_approach_req_l = wbc_approach_req;
-        wbc_approach_req_l.execute_trajectory = false;
-        wbc_approach_req_l.task_description.affordance_info_from = affordance_info_from;
-        wbc_approach_req_l.task_description.canonical_pose_from = canonical_pose_from;
-        rclcpp::spin_some(planner); // We wanna read current state here
-        auto wbc_approach_response = planner->plan(wbc_approach_req_l);
-        if (!wbc_approach_response.result.success || stop_token.stop_requested())
+        // Fill in grasp pose info for all approach requests
+        std::vector<cca_ros::PlanningRequest> reqs;
+        for (const auto &req : approach_reqs)
         {
-            std::lock_guard<std::mutex> lock(result_mutex);
-            completed_threads++;
-            result_cv.notify_one();
-            return;
+            auto req_l = req;
+            req_l.execute_trajectory = false;
+            req_l.task_description.affordance_info_from = affordance_info_from;
+            req_l.task_description.canonical_pose_from = canonical_pose_from;
+            reqs.push_back(req_l);
         }
 
-        // Update arm approach request, seeding start state from WBC result
-        auto arm_approach_req_l = arm_approach_req;
-        arm_approach_req_l.execute_trajectory = false;
-        arm_approach_req_l.task_description.affordance_info_from = affordance_info_from;
-        arm_approach_req_l.task_description.canonical_pose_from = canonical_pose_from;
-        const Eigen::VectorXd &wbc_traj_end_point = wbc_approach_response.result.cca_result.joint_trajectory.back();
-        const Eigen::VectorXd &arm_start_state =
-            wbc_traj_end_point.segment(arm_start_index_in_wbc_traj, arm_num_joints);
-        const double gripper_start_state = wbc_traj_end_point(arm_start_index_in_wbc_traj + arm_num_joints);
-        arm_approach_req_l.start_state.robot = arm_start_state;
-        arm_approach_req_l.start_state.gripper = gripper_start_state;
+        // Fill in affordance info for grab request (grab affordance is defined relative to the grasp pose)
+        auto grab_req_l = grab_req;
+        grab_req_l.execute_trajectory = false;
+        grab_req_l.task_description.affordance_info_from = affordance_info_from;
+        reqs.push_back(grab_req_l);
 
-        // Disable execution for arm grab request
-        auto arm_grab_req_l = arm_grab_req;
-        arm_grab_req_l.execute_trajectory = false;
-        arm_grab_req_l.task_description.affordance_info_from = affordance_info_from;
-
-        // Plan arm requests
-        std::vector<cca_ros::PlanningRequest> arm_reqs = {arm_approach_req_l, arm_grab_req_l};
-        auto arm_response = planner->plan(arm_reqs);
-        if (!arm_response.result.success || stop_token.stop_requested())
+        // Check if these requests are plannable with this grasp pose
+        if (!is_plannable(planner, reqs) || stop_token.stop_requested())
         {
             std::lock_guard<std::mutex> lock(result_mutex);
             completed_threads++;
@@ -121,7 +175,7 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
         {
             std::lock_guard<std::mutex> lock(result_mutex);
             if (!found_successful_plan)
-            { // Only set the first successful plan
+            {
                 found_successful_plan = true;
                 affordative_grasp_pose = grasp_pose;
             }
@@ -154,10 +208,10 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
 
     if (!found_successful_plan)
     {
-        return std::nullopt; // No affordative grasp pose found within timeout
+        return std::nullopt;
     }
 
-    // Set output
+    // Build and return the stamped pose
     geometry_msgs::msg::PoseStamped affordative_grasp_pose_stamped;
     affordative_grasp_pose_stamped.pose = affordative_grasp_pose;
     affordative_grasp_pose_stamped.header.stamp = grasp_poses.header.stamp;

--- a/cca_ros_features/src/cca_ros_features.cpp
+++ b/cca_ros_features/src/cca_ros_features.cpp
@@ -14,7 +14,7 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
 {
 
  // Set canonical_pose_from base for all planning requests
-    const std::string &grasp_pose_frame_id = grasp_poses->header.frame_id;
+    const std::string &grasp_pose_frame_id = grasp_poses.header.frame_id;
     affordance_util::PoseFrom canonical_pose_from_base;
     canonical_pose_from_base.method = affordance_util::PoseSpecificationMethod::FROM_FRAME_NAME;
     canonical_pose_from_base.frame_name = grasp_pose_frame_id;
@@ -36,10 +36,10 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
     // Create a planner per grasp pose
     // NOTE: geometry_msgs::msg::Pose has no hash, so we use index-based storage
     std::vector<std::pair<geometry_msgs::msg::Pose, std::shared_ptr<cca_ros::CcaRos>>> grasp_pose_to_planners;
-    for (size_t i = 0; i < grasp_poses->poses.size(); ++i)
+    for (size_t i = 0; i < grasp_poses.poses.size(); ++i)
     {
         auto planner = std::make_shared<cca_ros::CcaRos>("cca_ros_" + std::to_string(i), rclcpp::NodeOptions());
-        grasp_pose_to_planners.emplace_back(grasp_poses->poses[i], planner);
+        grasp_pose_to_planners.emplace_back(grasp_poses.poses[i], planner);
     }
 
     const size_t total_threads = grasp_pose_to_planners.size();
@@ -69,12 +69,12 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
         affordance_info_from.post_transform = grasp_pose_eigen.matrix();
 
         // Plan WBC approach
-        auto wbc_approach_req = *wbc_approach_req_ptr;
-        wbc_approach_req.execute_trajectory = false;
-        wbc_approach_req.task_description.affordance_info_from = affordance_info_from;
-        wbc_approach_req.task_description.canonical_pose_from = canonical_pose_from;
+        auto wbc_approach_req_l = wbc_approach_req;
+        wbc_approach_req_l.execute_trajectory = false;
+        wbc_approach_req_l.task_description.affordance_info_from = affordance_info_from;
+        wbc_approach_req_l.task_description.canonical_pose_from = canonical_pose_from;
         rclcpp::spin_some(planner); // We wanna read current state here
-        auto wbc_approach_response = planner->plan(wbc_approach_req);
+        auto wbc_approach_response = planner->plan(wbc_approach_req_l);
         if (!wbc_approach_response.result.success || stop_token.stop_requested())
         {
             std::lock_guard<std::mutex> lock(result_mutex);
@@ -84,24 +84,24 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
         }
 
         // Update arm approach request, seeding start state from WBC result
-        auto arm_approach_req = *arm_approach_req_ptr;
-        arm_approach_req.execute_trajectory = false;
-        arm_approach_req.task_description.affordance_info_from = affordance_info_from;
-        arm_approach_req.task_description.canonical_pose_from = canonical_pose_from;
+        auto arm_approach_req_l = arm_approach_req;
+        arm_approach_req_l.execute_trajectory = false;
+        arm_approach_req_l.task_description.affordance_info_from = affordance_info_from;
+        arm_approach_req_l.task_description.canonical_pose_from = canonical_pose_from;
         const Eigen::VectorXd &wbc_traj_end_point = wbc_approach_response.result.cca_result.joint_trajectory.back();
         const Eigen::VectorXd &arm_start_state =
             wbc_traj_end_point.segment(arm_start_index_in_wbc_traj, arm_num_joints);
         const double gripper_start_state = wbc_traj_end_point(arm_start_index_in_wbc_traj + arm_num_joints);
-        arm_approach_req.start_state.robot = arm_start_state;
-        arm_approach_req.start_state.gripper = gripper_start_state;
+        arm_approach_req_l.start_state.robot = arm_start_state;
+        arm_approach_req_l.start_state.gripper = gripper_start_state;
 
         // Disable execution for arm grab request
-        auto arm_grab_req = *arm_grab_req_ptr;
-        arm_grab_req.execute_trajectory = false;
-        arm_grab_req.task_description.affordance_info_from = affordance_info_from;
+        auto arm_grab_req_l = arm_grab_req;
+        arm_grab_req_l.execute_trajectory = false;
+        arm_grab_req_l.task_description.affordance_info_from = affordance_info_from;
 
         // Plan arm requests
-        std::vector<cca_ros::PlanningRequest> arm_reqs = {arm_approach_req, arm_grab_req};
+        std::vector<cca_ros::PlanningRequest> arm_reqs = {arm_approach_req_l, arm_grab_req_l};
         auto arm_response = planner->plan(arm_reqs);
         if (!arm_response.result.success || stop_token.stop_requested())
         {
@@ -136,7 +136,7 @@ std::optional<geometry_msgs::msg::PoseStamped> getAffordativeGraspPose(
     // Wait for first success, all threads to finish, or timeout
     {
         std::unique_lock<std::mutex> lock(result_mutex);
-        result_cv.wait_for(lock, timeout_,
+        result_cv.wait_for(lock, timeout,
                            [&]() { return found_successful_plan || completed_threads == total_threads; });
     }
 

--- a/cca_ros_msgs/srv/CcaRosValAndViz.srv
+++ b/cca_ros_msgs/srv/CcaRosValAndViz.srv
@@ -6,6 +6,7 @@ geometry_msgs/Vector3[] aff_screw_axes # vector of screw axes
 geometry_msgs/Point[] aff_locations # locations of the corresponding screw axes
 geometry_msgs/Pose[] aff_ref_poses # Reference poses for approach motion, corresponding to the affordance zero
 string ref_frame # reference frame for EE FK computation
+bool visualize # whether to visualize the task markers and the trajectory in RViz
 ---
 # Result
 bool success # whether planning and visualization was successful

--- a/cca_ros_rviz_plugin/README.md
+++ b/cca_ros_rviz_plugin/README.md
@@ -1,13 +1,10 @@
-
-
-
 # CCA RViz Plugin
 
-This package provides the source code for the **CCA RViz Plugin**, which enables intuitive, interactive specification and planning of constrained manipulation tasks — lowering the barrier for non-expert users to work with constrained motion planning.
+This package provides the source code for the **CCA RViz Plugin**, which enables intuitive, interactive specification and planning of constrained manipulation tasks, making real-world constrained manipulation accessible to non-expert users. Task examples include opening doors, turning valves, manipulating drawers, moving objects out of the way, and many more.
 
-The plugin is based on the **Closed-Chain Affordance (CCA) framework** (see [references](#references) below), which enables efficient planning of common constrained manipulation tasks by capturing the motions that objects afford to the robot (*task affordances*) compactly as a screw — a unified mathematical representation encompassing rotation, translation, and screw motion. Task examples include opening doors, turning valves, manipulating drawers, moving objects out of the way, and many more.
+The plugin is based on the **Closed-Chain Affordance (CCA) framework** (see [references](#references) below), which enables efficient planning of common manipulation tasks by capturing the motions that objects afford to the robot (*task affordances*) compactly as a screw — a unified mathematical representation encompassing rotation, translation, and screw motion. 
 
-The plugin exposes a visual interface in which users describe tasks interactively using an arrow defining the axis of task motion (i.e. the screw axis), the motion type (rotation, translation, or screw), and an **affordative grasp pose** — the grasp configuration that enables the intended task motion.
+The plugin exposes a visual interface in which users describe tasks interactively using an arrow defining the axis of task motion (i.e. the screw axis), the motion type (rotation, translation, or screw), and an affordative grasp pose — the grasp pose that enables the intended task motion. By incorporating real-world context, for instance, via point cloud data, users can seamlessly apply the plugin to real-world tasks, as demonstrated below.
 
 ## Planning Types
 
@@ -30,7 +27,7 @@ https://github.com/user-attachments/assets/7557b58b-5c65-4966-8dbc-f8f8744902ce
 https://github.com/user-attachments/assets/bbd4796e-4a79-4b03-8980-ad6ccaf248c8
 
 
-### 3. EE Orientation
+### 3. EE Orientation Only
 Given a screw axis located at the end-effector, computes a joint trajectory that reorients the EE in place by a desired angle.
 
 https://github.com/user-attachments/assets/cd856ea8-20f6-4f7e-a15a-2b85af197175

--- a/cca_ros_rviz_plugin/README.md
+++ b/cca_ros_rviz_plugin/README.md
@@ -1,1 +1,31 @@
-This package provides the source code for the CCA RViz plugin, enabling interactive planning. 
+# CCA RViz Plugin
+
+This package provides the source code for the **CCA RViz Plugin**, which enables intuitive, interactive specification and planning of constrained manipulation tasks — lowering the barrier for non-expert users to work with constrained motion planning.
+
+The plugin is based on the **Closed-Chain Affordance (CCA) framework** (see [references](#references) below), which enables efficient planning of common constrained manipulation tasks by capturing the motions that objects afford to the robot (*task affordances*) compactly as a screw — a unified mathematical representation encompassing rotation, translation, and screw motion. Task examples include opening doors, turning valves, manipulating drawers, moving objects out of the way, and many more.
+
+The plugin exposes a visual interface in which users describe tasks interactively using an arrow defining the axis of task motion (i.e. the screw axis), the motion type (rotation, translation, or screw), and an **affordative grasp pose** — the grasp configuration that enables the intended task motion.
+
+## Planning Types
+
+### 1. Approach
+Given a screw axis, its motion type, and an affordative grasp pose, computes a joint trajectory that moves the robot to a target grasp pose along the task path.
+
+> *Example: Move to grasp the valve at its 90° position.*
+
+### 2. Affordance
+Given a screw axis and its motion type, and assuming the robot is already grasping the object, computes a joint trajectory that executes the desired constrained motion along the screw axis.
+
+> *Example: Rotate a valve 90°, or pull a drawer open by 40 cm.*
+
+### 3. EE Orientation
+Given a screw axis located at the end-effector, computes a joint trajectory that reorients the EE in place by a desired angle.
+
+### 4. Pose Goal
+Given a desired end-effector target pose, computes a joint trajectory to reach that pose.
+
+## References
+
+- Panthi, J., Alambeigi, F., and Pryor, M. "A Closed-Chain Approach to Generating Affordance Joint Trajectories for Robotic Manipulators." *IEEE Transactions on Robotics*, 2025.
+
+- Panthi, J., Alambeigi, F., and Pryor, M. "Unifying Task-Aware Approach, Grasp, and Post-Grasp Manipulation as a Closed-Chain Mechanism." *IEEE International Conference on Robotics & Automation (ICRA) Workshop on Extreme Manipulation* (Accepted), 2026.

--- a/cca_ros_rviz_plugin/README.md
+++ b/cca_ros_rviz_plugin/README.md
@@ -1,3 +1,6 @@
+
+
+
 # CCA RViz Plugin
 
 This package provides the source code for the **CCA RViz Plugin**, which enables intuitive, interactive specification and planning of constrained manipulation tasks — lowering the barrier for non-expert users to work with constrained motion planning.
@@ -13,16 +16,29 @@ Given a screw axis, its motion type, and an affordative grasp pose, computes a j
 
 > *Example: Move to grasp the valve at its 90° position.*
 
+https://github.com/user-attachments/assets/37b8e0b6-4811-4697-87f7-adb890f1a5c5
+
 ### 2. Affordance
 Given a screw axis and its motion type, and assuming the robot is already grasping the object, computes a joint trajectory that executes the desired constrained motion along the screw axis.
 
-> *Example: Rotate a valve 90°, or pull a drawer open by 40 cm.*
+> *Example: Rotate a valve 180°, or pull a drawer open by 40 cm.*
+
+https://github.com/user-attachments/assets/7557b58b-5c65-4966-8dbc-f8f8744902ce
+
+#### Approach and affordance planning demonstration on real robot
+
+https://github.com/user-attachments/assets/bbd4796e-4a79-4b03-8980-ad6ccaf248c8
+
 
 ### 3. EE Orientation
 Given a screw axis located at the end-effector, computes a joint trajectory that reorients the EE in place by a desired angle.
 
+https://github.com/user-attachments/assets/cd856ea8-20f6-4f7e-a15a-2b85af197175
+
 ### 4. Pose Goal
 Given a desired end-effector target pose, computes a joint trajectory to reach that pose.
+
+https://github.com/user-attachments/assets/b5abf628-08f3-4f51-a0ac-8df07bd139d6
 
 ## References
 

--- a/cca_ros_rviz_plugin/include/cca_ros_rviz_plugin/cca_ros_rviz_plugin.hpp
+++ b/cca_ros_rviz_plugin/include/cca_ros_rviz_plugin/cca_ros_rviz_plugin.hpp
@@ -2,7 +2,7 @@
 //      Title     : cca_ros_rviz_plugin.hpp
 //      Project   : cca_ros_rviz_plugin
 //      Created   : Spring 2025
-//      Author    : Janak Panthi (Crasun Jans) and John Lyle
+//      Author    : Janak Panthi (Crasun Jans)
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CCA_ROS_RVIZ_PLUGIN_HPP_
@@ -270,7 +270,7 @@ class CcaRosRvizPlugin : public rviz_common::Panel, public interactive_marker_ma
 
     const std::map<QString, cc_affordance_planner::PlanningType> planning_type_map_ = {
         {QString("Affordance"), cc_affordance_planner::PlanningType::AFFORDANCE},
-        {QString("Cartesian Goal"), cc_affordance_planner::PlanningType::CARTESIAN_GOAL},
+        {QString("Pose Goal"), cc_affordance_planner::PlanningType::CARTESIAN_GOAL},
         {QString("Approach"), cc_affordance_planner::PlanningType::APPROACH},
         {QString("EE Orientation Only"), cc_affordance_planner::PlanningType::EE_ORIENTATION_ONLY}};
 

--- a/cca_ros_rviz_plugin/src/cca_ros_rviz_plugin/cca_ros_rviz_plugin.cpp
+++ b/cca_ros_rviz_plugin/src/cca_ros_rviz_plugin/cca_ros_rviz_plugin.cpp
@@ -187,7 +187,7 @@ void CcaRosRvizPlugin::mode_selected_()
         set_combo_box_controls_(axis_bl_, true);
         axis_bl_.combo_box->setCurrentText("");
     }
-    else if (selected_mode == "Cartesian Goal"){ 
+    else if (selected_mode == "Pose Goal"){ 
         
 	// We only need the frame marker
         draw_frame_im_();

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -403,7 +403,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
 	    moveit_planned_path_pub_->publish(display_trajectory);
          }
 
-        {
+        if (serv_req->visualize){
         std::lock_guard<std::mutex> viz_lock(viz_mutex_);
 
         // Clear messages

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -275,10 +275,10 @@ class CcaRosValAndVizServer : public rclcpp::Node
 	}
 
         // Get the joint model group for the requested planning group
-        moveit::core::JointModelGroup *joint_model_group_ = robot_model_->getJointModelGroup(serv_req->planning_group);
+        moveit::core::JointModelGroup *joint_model_group = robot_model_->getJointModelGroup(serv_req->planning_group);
 
 	// Capture joint names for the planning group
-	std::vector<std::string> joint_names = joint_model_group_->getVariableNames();
+	std::vector<std::string> joint_names = joint_model_group->getVariableNames();
 
         // Capture joint limits so we could log joint-limit violations later
         std::map<std::string, moveit::core::VariableBounds> joint_limit_map;
@@ -302,7 +302,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
 
             // Set the planning goal state to that trajectory point
             moveit::core::RobotState goal_state(current_state); // start from current state to preserve unplanned joints
-            goal_state.setJointGroupPositions(joint_model_group_, planning_end_state);
+            goal_state.setJointGroupPositions(joint_model_group, planning_end_state);
 
             // Acquire read-only lock on the planning scene before doing anything
             {
@@ -319,7 +319,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
 		collision_result.clear();
 
 		// Check and store violation check
-		bool joint_limit_violation = !goal_state.satisfiesBounds(joint_model_group_);
+		bool joint_limit_violation = !goal_state.satisfiesBounds(joint_model_group);
 		lscene->checkCollision(collision_request, collision_result, goal_state);
 		bool collision_violation = collision_result.collision;
 

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -3,31 +3,6 @@
 //      Project   : cca_ros_viz
 //      Created   : Jan 2024
 //      Author    : Janak Panthi (Crasun Jans)
-//      Copyright : Copyright© The University of Texas at Austin, 2014-2026. All
-//      rights reserved.
-//
-//          All files within this directory are subject to the following, unless
-//          an alternative license is explicitly included within the text of
-//          each file.
-//
-//          This software and documentation constitute an unpublished work
-//          and contain valuable trade secrets and proprietary information
-//          belonging to the University. None of the foregoing material may be
-//          copied or duplicated or disclosed without the express, written
-//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
-//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
-//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
-//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
-//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
-//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
-//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
-//          University be liable for incidental, special, indirect, direct or
-//          consequential damages or loss of profits, interruption of business,
-//          or related expenses which may arise from use of software or
-//          documentation, including but not limited to those resulting from
-//          defects in software and/or documentation, or loss or inaccuracy of
-//          data of any kind.
-//
 ///////////////////////////////////////////////////////////////////////////////
 #include <cca_ros_msgs/srv/cca_ros_val_and_viz.hpp>
 #include <fmt/core.h>

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -31,8 +31,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include <fmt/core.h>
 #include <iomanip>
-#include <sstream>  
-#include <string>  
+#include <mutex>
+#include <sstream>
+#include <string>
 #include <rclcpp/rclcpp.hpp>
 #include <cca_ros_msgs/srv/cca_ros_val_and_viz.hpp>
 
@@ -61,9 +62,11 @@ class CcaRosValAndVizServer : public rclcpp::Node
         joint_states_topic_ = ros_cpp_util::get_required_str_param(this, "cca_joint_states_topic");
 
         // Create and advertise planning and visualization service
+        reentrant_cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
         srv_ = this->create_service<cca_ros_msgs::srv::CcaRosValAndViz>(
             val_and_viz_ss_name_, std::bind(&CcaRosValAndVizServer::cca_ros_viz_server_callback_, this,
-                                             std::placeholders::_1, std::placeholders::_2));
+                                             std::placeholders::_1, std::placeholders::_2),
+            rmw_qos_profile_services_default, reentrant_cb_group_);
 
         // Initialize the publisher to show moveit planned path
         moveit_planned_path_pub_ =
@@ -83,7 +86,11 @@ class CcaRosValAndVizServer : public rclcpp::Node
     {
         // Spin node in a separate thread so we can start reading robot state
         node_handle = this->shared_from_this();
-        spinner_thread_ = std::thread([this]() { rclcpp::spin(node_handle); });
+        spinner_thread_ = std::thread([this]() {
+            rclcpp::executors::MultiThreadedExecutor executor;
+            executor.add_node(node_handle);
+            executor.spin();
+        });
 
         // Initialize planning parameters
         robot_model_loader::RobotModelLoaderPtr robot_model_loader =
@@ -118,6 +125,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
     std::thread spinner_thread_; // To spin the node in a separate thread
 
     rclcpp::Logger node_logger_;                                       // logger associated with the node
+    rclcpp::CallbackGroup::SharedPtr reentrant_cb_group_;              // allows parallel service callbacks
     rclcpp::Service<cca_ros_msgs::srv::CcaRosValAndViz>::SharedPtr srv_; // joint traj plan and visualization service
     rclcpp::Publisher<moveit_msgs::msg::DisplayTrajectory>::SharedPtr
         moveit_planned_path_pub_; // publisher to show moveit planned path
@@ -125,8 +133,8 @@ class CcaRosValAndVizServer : public rclcpp::Node
     planning_scene_monitor::PlanningSceneMonitorPtr psm_;
     moveit::core::RobotStatePtr robot_state_;
     moveit::core::RobotModelPtr robot_model_;
-    moveit::core::JointModelGroup *joint_model_group_;
     rviz_visual_tools::RvizVisualToolsPtr rviz_visual_tools_;
+    std::mutex viz_mutex_; // serializes rviz_visual_tools_ access across parallel callbacks
 
     std::string val_and_viz_ss_name_;
     std::string rviz_fixed_frame_;
@@ -244,8 +252,11 @@ class CcaRosValAndVizServer : public rclcpp::Node
 
         serv_res->success = false;// start as false
 
+        {
+            std::lock_guard<std::mutex> viz_lock(viz_mutex_);
         // Clear messages
         rviz_visual_tools_->deleteAllMarkers();
+	}
 
         RCLCPP_INFO(node_logger_, "Planning and visualizing the trajectory");
 
@@ -270,6 +281,8 @@ class CcaRosValAndVizServer : public rclcpp::Node
 	}
 
         // Draw affordance screw axes and optionally, aff ref frames
+        {
+            std::lock_guard<std::mutex> viz_lock(viz_mutex_);
         for (size_t task_idx = 0; task_idx < serv_req->aff_screw_axes.size(); ++task_idx){
             const auto aff_screw_axis = serv_req->aff_screw_axes.at(task_idx);
 	    const auto aff_location = serv_req->aff_locations.at(task_idx);
@@ -302,8 +315,10 @@ class CcaRosValAndVizServer : public rclcpp::Node
             rviz_visual_tools_->trigger();
 	}
 
+        }
+
         // Get the joint model group for the requested planning group
-        joint_model_group_ = robot_model_->getJointModelGroup(serv_req->planning_group);
+        moveit::core::JointModelGroup *joint_model_group_ = robot_model_->getJointModelGroup(serv_req->planning_group);
 
 	// Capture joint names for the planning group
 	std::vector<std::string> joint_names = joint_model_group_->getVariableNames();
@@ -429,11 +444,14 @@ class CcaRosValAndVizServer : public rclcpp::Node
 	    moveit_planned_path_pub_->publish(display_trajectory);
 
             // Publish the tool trajectory
-	    for (const auto& pose : viz_cart_traj)
-	    {
-	        rviz_visual_tools_->publishAxis(this->transform_pose_to_world_frame(T_w_r, pose));
-	    }
-	    rviz_visual_tools_->trigger();  // only once after batching
+            {
+                std::lock_guard<std::mutex> viz_lock(viz_mutex_);
+	        for (const auto& pose : viz_cart_traj)
+	        {
+	            rviz_visual_tools_->publishAxis(this->transform_pose_to_world_frame(T_w_r, pose));
+	        }
+	        rviz_visual_tools_->trigger();  // only once after batching
+            }
         }
 
 	// Set response

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -29,13 +29,13 @@
 //          data of any kind.
 //
 ///////////////////////////////////////////////////////////////////////////////
+#include <cca_ros_msgs/srv/cca_ros_val_and_viz.hpp>
 #include <fmt/core.h>
 #include <iomanip>
 #include <mutex>
+#include <rclcpp/rclcpp.hpp>
 #include <sstream>
 #include <string>
-#include <rclcpp/rclcpp.hpp>
-#include <cca_ros_msgs/srv/cca_ros_val_and_viz.hpp>
 
 // MoveIt
 #include <moveit/kinematic_constraints/utils.h>
@@ -53,7 +53,8 @@ class CcaRosValAndVizServer : public rclcpp::Node
 {
   public:
     explicit CcaRosValAndVizServer(const rclcpp::NodeOptions &options)
-        : Node("cca_ros_val_and_viz", options), node_logger_(this->get_logger()), val_and_viz_ss_name_("/cca_ros_val_and_viz") 
+        : Node("cca_ros_val_and_viz", options), node_logger_(this->get_logger()),
+          val_and_viz_ss_name_("/cca_ros_val_and_viz")
     {
 
         // Extract parameters
@@ -64,14 +65,15 @@ class CcaRosValAndVizServer : public rclcpp::Node
         // Create and advertise planning and visualization service
         reentrant_cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
         srv_ = this->create_service<cca_ros_msgs::srv::CcaRosValAndViz>(
-            val_and_viz_ss_name_, std::bind(&CcaRosValAndVizServer::cca_ros_viz_server_callback_, this,
-                                             std::placeholders::_1, std::placeholders::_2),
+            val_and_viz_ss_name_,
+            std::bind(&CcaRosValAndVizServer::cca_ros_viz_server_callback_, this, std::placeholders::_1,
+                      std::placeholders::_2),
             rmw_qos_profile_services_default, reentrant_cb_group_);
 
         // Initialize the publisher to show moveit planned path
         moveit_planned_path_pub_ =
             this->create_publisher<moveit_msgs::msg::DisplayTrajectory>("/display_planned_path", 1);
-        RCLCPP_INFO_STREAM(node_logger_, val_and_viz_ss_name_ <<" service is active");
+        RCLCPP_INFO_STREAM(node_logger_, val_and_viz_ss_name_ << " service is active");
     }
 
     ~CcaRosValAndVizServer()
@@ -106,17 +108,17 @@ class CcaRosValAndVizServer : public rclcpp::Node
         psm_->startStateMonitor(
             joint_states_topic_); // listens to joint state updates and attached collision object changes
 
-        // Make the planning‐scene service available for diffs and publish the scene -- needed to reflect joint states correctly
+        // Make the planning‐scene service available for diffs and publish the scene -- needed to reflect joint states
+        // correctly
         psm_->providePlanningSceneService();
         psm_->startPublishingPlanningScene(planning_scene_monitor::PlanningSceneMonitor::UPDATE_SCENE);
 
         rviz_visual_tools_.reset(
             new rviz_visual_tools::RvizVisualTools(rviz_fixed_frame_, val_and_viz_ss_name_, node_handle));
-        rviz_visual_tools_->loadMarkerPub(); 	    // Initialize publisher
-        rviz_visual_tools_->setLifetime(0.0);       // Publish markers with zero timestamp to avoid future extrapolation
-        rviz_visual_tools_->enableFrameLocking();   // Keep markers fixed in the RViz frame to bypass TF transforms
-        rviz_visual_tools_->enableBatchPublishing();// Batch publishing for efficiency
-
+        rviz_visual_tools_->loadMarkerPub();      // Initialize publisher
+        rviz_visual_tools_->setLifetime(0.0);     // Publish markers with zero timestamp to avoid future extrapolation
+        rviz_visual_tools_->enableFrameLocking(); // Keep markers fixed in the RViz frame to bypass TF transforms
+        rviz_visual_tools_->enableBatchPublishing(); // Batch publishing for efficiency
     }
 
   private:
@@ -124,8 +126,8 @@ class CcaRosValAndVizServer : public rclcpp::Node
     rclcpp::Node::SharedPtr node_handle;
     std::thread spinner_thread_; // To spin the node in a separate thread
 
-    rclcpp::Logger node_logger_;                                       // logger associated with the node
-    rclcpp::CallbackGroup::SharedPtr reentrant_cb_group_;              // allows parallel service callbacks
+    rclcpp::Logger node_logger_;                                         // logger associated with the node
+    rclcpp::CallbackGroup::SharedPtr reentrant_cb_group_;                // allows parallel service callbacks
     rclcpp::Service<cca_ros_msgs::srv::CcaRosValAndViz>::SharedPtr srv_; // joint traj plan and visualization service
     rclcpp::Publisher<moveit_msgs::msg::DisplayTrajectory>::SharedPtr
         moveit_planned_path_pub_; // publisher to show moveit planned path
@@ -140,36 +142,38 @@ class CcaRosValAndVizServer : public rclcpp::Node
     std::string rviz_fixed_frame_;
     std::string joint_states_topic_;
 
-    std::string get_joint_limit_violation_log_(const moveit::core::RobotState& state, const std::map<std::string, moveit::core::VariableBounds>& joint_limit_map) {
+    std::string get_joint_limit_violation_log_(
+        const moveit::core::RobotState &state,
+        const std::map<std::string, moveit::core::VariableBounds> &joint_limit_map)
+    {
         const int JOINT_NAME_WIDTH = 30;
         const int VALUE_WIDTH = 15;
         const int LIMIT_WIDTH = 15;
         const int TOTAL_WIDTH = JOINT_NAME_WIDTH + VALUE_WIDTH + LIMIT_WIDTH + LIMIT_WIDTH;
         const int FLOAT_PRECISION = 4;
-        
+
         std::stringstream error_msg;
         error_msg << std::fixed << std::setprecision(FLOAT_PRECISION);
         error_msg << "Offending joints:\n";
-        error_msg << std::setw(JOINT_NAME_WIDTH) << std::left << "Joint name" 
-                  << std::setw(VALUE_WIDTH) << "Value" 
-                  << std::setw(LIMIT_WIDTH) << "Min Limit" 
-                  << std::setw(LIMIT_WIDTH) << "Max Limit" << "\n";
+        error_msg << std::setw(JOINT_NAME_WIDTH) << std::left << "Joint name" << std::setw(VALUE_WIDTH) << "Value"
+                  << std::setw(LIMIT_WIDTH) << "Min Limit" << std::setw(LIMIT_WIDTH) << "Max Limit"
+                  << "\n";
         error_msg << std::string(TOTAL_WIDTH, '-') << "\n";
-        
-        for (const auto& [joint_name, bounds] : joint_limit_map) {
-            const moveit::core::JointModel* joint_model = 
-                state.getRobotModel()->getJointModel(joint_name);
-            
-            if (joint_model && !state.satisfiesBounds(joint_model)) {
+
+        for (const auto &[joint_name, bounds] : joint_limit_map)
+        {
+            const moveit::core::JointModel *joint_model = state.getRobotModel()->getJointModel(joint_name);
+
+            if (joint_model && !state.satisfiesBounds(joint_model))
+            {
                 const double value = state.getVariablePosition(joint_name);
-                
-                error_msg << std::setw(JOINT_NAME_WIDTH) << std::left << joint_name
-                          << std::setw(VALUE_WIDTH) << value
-                          << std::setw(LIMIT_WIDTH) << bounds.min_position_
-                          << std::setw(LIMIT_WIDTH) << bounds.max_position_ << "\n";
+
+                error_msg << std::setw(JOINT_NAME_WIDTH) << std::left << joint_name << std::setw(VALUE_WIDTH) << value
+                          << std::setw(LIMIT_WIDTH) << bounds.min_position_ << std::setw(LIMIT_WIDTH)
+                          << bounds.max_position_ << "\n";
             }
         }
-        
+
         return error_msg.str();
     }
 
@@ -202,58 +206,57 @@ class CcaRosValAndVizServer : public rclcpp::Node
     }
 
     // Reorders the trajectory to match a given joint name order (e.g., for a planning group or the full robot)
-    trajectory_msgs::msg::JointTrajectory reorder_trajectory_(
-        const trajectory_msgs::msg::JointTrajectory &input_traj,
-        const std::vector<std::string> &target_joint_names, 
-	const moveit::core::RobotState& current_state)
+    trajectory_msgs::msg::JointTrajectory reorder_trajectory_(const trajectory_msgs::msg::JointTrajectory &input_traj,
+                                                              const std::vector<std::string> &target_joint_names,
+                                                              const moveit::core::RobotState &current_state)
     {
         trajectory_msgs::msg::JointTrajectory ordered_traj;
         ordered_traj.header = input_traj.header;
         ordered_traj.joint_names = target_joint_names;
-    
+
         // Build name → index map from input
         std::unordered_map<std::string, size_t> name_to_index;
         for (size_t i = 0; i < input_traj.joint_names.size(); ++i)
         {
-    	name_to_index[input_traj.joint_names[i]] = i;
+            name_to_index[input_traj.joint_names[i]] = i;
         }
-    
+
         // Reorder each point according to target_joint_names
         for (const auto &point : input_traj.points)
         {
-    	trajectory_msgs::msg::JointTrajectoryPoint new_point;
-    	new_point.time_from_start = point.time_from_start;
-    	new_point.positions.resize(target_joint_names.size());
-    
-    	for (size_t i = 0; i < target_joint_names.size(); ++i)
-    	{
-    	    const auto &name = target_joint_names[i];
-    	    auto it = name_to_index.find(name);
-    	    if (it != name_to_index.end())
-    	    {
-    		new_point.positions[i] = point.positions[it->second];
-    	    }
-    	    else
-    	    {
-    		new_point.positions[i] = current_state.getVariablePosition(name);
-    	    }
-    	}
-    
-    	ordered_traj.points.push_back(std::move(new_point));
+            trajectory_msgs::msg::JointTrajectoryPoint new_point;
+            new_point.time_from_start = point.time_from_start;
+            new_point.positions.resize(target_joint_names.size());
+
+            for (size_t i = 0; i < target_joint_names.size(); ++i)
+            {
+                const auto &name = target_joint_names[i];
+                auto it = name_to_index.find(name);
+                if (it != name_to_index.end())
+                {
+                    new_point.positions[i] = point.positions[it->second];
+                }
+                else
+                {
+                    new_point.positions[i] = current_state.getVariablePosition(name);
+                }
+            }
+
+            ordered_traj.points.push_back(std::move(new_point));
         }
-    
+
         return ordered_traj;
     }
-
 
     void cca_ros_viz_server_callback_(const std::shared_ptr<cca_ros_msgs::srv::CcaRosValAndViz::Request> serv_req,
                                       std::shared_ptr<cca_ros_msgs::srv::CcaRosValAndViz::Response> serv_res)
     {
 
-        serv_res->success = false;// start as false
+        serv_res->success = false; // start as false
 
-        RCLCPP_INFO(node_logger_, "Validating requested joint trajectory for planning group [%s] with reference frame [%s]",
-		    serv_req->planning_group.c_str(), serv_req->ref_frame.c_str());
+        RCLCPP_INFO(node_logger_,
+                    "Validating requested joint trajectory for planning group [%s] with reference frame [%s]",
+                    serv_req->planning_group.c_str(), serv_req->ref_frame.c_str());
 
         // Get fresh robot state
         moveit::core::RobotState current_state(*robot_state_);
@@ -265,24 +268,25 @@ class CcaRosValAndVizServer : public rclcpp::Node
         // Get the joint model group for the requested planning group
         moveit::core::JointModelGroup *joint_model_group = robot_model_->getJointModelGroup(serv_req->planning_group);
 
-	// Capture joint names for the planning group
-	std::vector<std::string> joint_names = joint_model_group->getVariableNames();
+        // Capture joint names for the planning group
+        std::vector<std::string> joint_names = joint_model_group->getVariableNames();
 
         // Capture joint limits so we could log joint-limit violations later
         std::map<std::string, moveit::core::VariableBounds> joint_limit_map;
-        for (const std::string& joint_name : joint_names) {
-            joint_limit_map[joint_name] = 
-                robot_model_->getVariableBounds(joint_name);
+        for (const std::string &joint_name : joint_names)
+        {
+            joint_limit_map[joint_name] = robot_model_->getVariableBounds(joint_name);
         }
 
-	// (Re)order trajectory to match MoveIt planning group order
-	trajectory_msgs::msg::JointTrajectory ordered_group_traj = reorder_trajectory_(serv_req->joint_traj, joint_names, current_state);
+        // (Re)order trajectory to match MoveIt planning group order
+        trajectory_msgs::msg::JointTrajectory ordered_group_traj =
+            reorder_trajectory_(serv_req->joint_traj, joint_names, current_state);
 
         std::chrono::microseconds total_viol_check_duration{0}; // for joint limits and collision checking
 
-	size_t pt_index = 0;
-	size_t first_violation_index = ordered_group_traj.points.size(); // Initialize to full trajectory length
-	bool violation_found = false;
+        size_t pt_index = 0;
+        size_t first_violation_index = ordered_group_traj.points.size(); // Initialize to full trajectory length
+        bool violation_found = false;
         for (const auto &point : ordered_group_traj.points)
         {
             // Copy the joint trajectory point to a std::vector<double> type
@@ -296,177 +300,198 @@ class CcaRosValAndVizServer : public rclcpp::Node
             {
                 planning_scene_monitor::LockedPlanningSceneRO lscene(psm_);
 
-		// Check for joint limit and collision violation
-		auto start_time = std::chrono::high_resolution_clock::now(); // start time for this point in traj
+                // Check for joint limit and collision violation
+                auto start_time = std::chrono::high_resolution_clock::now(); // start time for this point in traj
 
-		// Set up collision requests and results
-		collision_detection::CollisionRequest collision_request;
-		collision_request.contacts = true;
-		collision_request.max_contacts = 1000;
-		collision_detection::CollisionResult collision_result;
-		collision_result.clear();
+                // Set up collision requests and results
+                collision_detection::CollisionRequest collision_request;
+                collision_request.contacts = true;
+                collision_request.max_contacts = 1000;
+                collision_detection::CollisionResult collision_result;
+                collision_result.clear();
 
-		// Check and store violation check
-		bool joint_limit_violation = !goal_state.satisfiesBounds(joint_model_group);
-		lscene->checkCollision(collision_request, collision_result, goal_state);
-		bool collision_violation = collision_result.collision;
+                // Check and store violation check
+                bool joint_limit_violation = !goal_state.satisfiesBounds(joint_model_group);
+                lscene->checkCollision(collision_request, collision_result, goal_state);
+                bool collision_violation = collision_result.collision;
 
-		// Capture how long it took to check for violations
-		auto end_time = std::chrono::high_resolution_clock::now(); // stop time for this point in traj
-		auto point_duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
-		total_viol_check_duration += point_duration;
+                // Capture how long it took to check for violations
+                auto end_time = std::chrono::high_resolution_clock::now(); // stop time for this point in traj
+                auto point_duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
+                total_viol_check_duration += point_duration;
 
-		// Log violation
-		if (joint_limit_violation || collision_violation) {
+                // Log violation
+                if (joint_limit_violation || collision_violation)
+                {
 
-		    std::string violation_type =
-                    (joint_limit_violation && collision_violation) ? "Joint Limit Violation & Collision" :
-                    joint_limit_violation ? "Joint Limit Violation" : "Collision";
+                    std::string violation_type = (joint_limit_violation && collision_violation)
+                                                     ? "Joint Limit Violation & Collision"
+                                                 : joint_limit_violation ? "Joint Limit Violation"
+                                                                         : "Collision";
 
-		    
-		    const double* goal_positions = goal_state.getVariablePositions();
-		    size_t num_joints = goal_state.getVariableCount();  // Get the number of joint values
+                    const double *goal_positions = goal_state.getVariablePositions();
+                    size_t num_joints = goal_state.getVariableCount(); // Get the number of joint values
 
-		    std::ostringstream oss;
-		    for (size_t k = 0; k < num_joints; ++k) {
-		        if (k > 0) oss << ", ";
-		        oss << goal_positions[k];
-		    }
+                    std::ostringstream oss;
+                    for (size_t k = 0; k < num_joints; ++k)
+                    {
+                        if (k > 0)
+                            oss << ", ";
+                        oss << goal_positions[k];
+                    }
 
-		    RCLCPP_ERROR(node_logger_, "Generated trajectory violates constraints [%s] at point[%zu]: [%s]",
-		    	     violation_type.c_str(), pt_index, oss.str().c_str());
+                    RCLCPP_ERROR(node_logger_, "Generated trajectory violates constraints [%s] at point[%zu]: [%s]",
+                                 violation_type.c_str(), pt_index, oss.str().c_str());
 
-		    // If collision occurs, print the contacts
-		    if (collision_violation){
-			    collision_detection::CollisionResult::ContactMap::const_iterator it;
-			    for (it = collision_result.contacts.begin(); it != collision_result.contacts.end(); ++it)
-			    {
-			      RCLCPP_ERROR(node_logger_, "Contact between: %s and %s", it->first.first.c_str(), it->first.second.c_str());
-			    }
-		    
-		    }
+                    // If collision occurs, print the contacts
+                    if (collision_violation)
+                    {
+                        collision_detection::CollisionResult::ContactMap::const_iterator it;
+                        for (it = collision_result.contacts.begin(); it != collision_result.contacts.end(); ++it)
+                        {
+                            RCLCPP_ERROR(node_logger_, "Contact between: %s and %s", it->first.first.c_str(),
+                                         it->first.second.c_str());
+                        }
+                    }
 
-		    // If joint-limit violation occurs, print the offending joints and info
-		    if (joint_limit_violation){	
-                            const std::string jl_err_log = get_joint_limit_violation_log_(goal_state, joint_limit_map);  
-			    RCLCPP_ERROR(node_logger_, jl_err_log.c_str());
-		    }
+                    // If joint-limit violation occurs, print the offending joints and info
+                    if (joint_limit_violation)
+                    {
+                        const std::string jl_err_log = get_joint_limit_violation_log_(goal_state, joint_limit_map);
+                        RCLCPP_ERROR(node_logger_, jl_err_log.c_str());
+                    }
 
-		    // Mark violation found and store the index, then break
-		    violation_found = true;
-		    first_violation_index = pt_index;
-		    break; 
-
-		}
+                    // Mark violation found and store the index, then break
+                    violation_found = true;
+                    first_violation_index = pt_index;
+                    break;
+                }
             }
-	    ++pt_index;
+            ++pt_index;
         }
-        if (serv_req->visualize){
-        RCLCPP_INFO(node_logger_, "Visualizing requested joint trajectory");
 
-	// Transform the trajectory to the full robot trajectory for visualization, i.e. by adding the current state of the unplanned joints
-	trajectory_msgs::msg::JointTrajectory ordered_robot_traj = reorder_trajectory_(serv_req->joint_traj, current_state.getVariableNames(), current_state);
+	// Visualize the trajectory and affordances if requested, even if violation is found, but only up to the violation point
 
-	// Truncate trajectories for visualization if violation was found
-	trajectory_msgs::msg::JointTrajectory viz_joint_traj = ordered_robot_traj;
-        auto viz_cart_traj = serv_req->cartesian_traj; 
-	if (violation_found && first_violation_index > 0) {
-            // Keep only the points up to (but not including) the violation point for visualization
-	    viz_joint_traj.points.resize(first_violation_index);
-            viz_cart_traj.resize(first_violation_index);
-	}
+        if (serv_req->visualize)
+        {
+            RCLCPP_INFO(node_logger_, "Visualizing requested joint trajectory");
 
-	const bool has_viz_traj = !viz_joint_traj.points.empty(); // Check if there's anything to visualize after truncation
+            // Transform the trajectory to the full robot trajectory for visualization, i.e. by adding the current state
+            // of the unplanned joints
+            trajectory_msgs::msg::JointTrajectory ordered_robot_traj =
+                reorder_trajectory_(serv_req->joint_traj, current_state.getVariableNames(), current_state);
 
-        // Capture T_w_r, the HTM from world frame, usually the root frame of the urdf to the service request reference
-        // frame
-        Eigen::Isometry3d T_w_r = current_state.getGlobalLinkTransform(serv_req->ref_frame);
-
-        // Validate affordance info sizes
-        if (serv_req->aff_screw_axes.size() != serv_req->aff_locations.size() ||
-	    serv_req->aff_screw_axes.size() != serv_req->aff_ref_poses.size())
-	{
-	    RCLCPP_ERROR(node_logger_,
-			 "Mismatch in the size of affordance screw axes, locations, and reference pose vectors");
-	    return;
-	}
-
-         {
-        std::lock_guard<std::mutex> viz_lock(viz_mutex_);
-
-        // Clear messages
-        rviz_visual_tools_->deleteAllMarkers();
-
-        // Draw affordance screw axes and optionally, aff ref frames
-        for (size_t task_idx = 0; task_idx < serv_req->aff_screw_axes.size(); ++task_idx){
-            const auto aff_screw_axis = serv_req->aff_screw_axes.at(task_idx);
-	    const auto aff_location = serv_req->aff_locations.at(task_idx);
-            const auto aff_ref_pose_msg = serv_req->aff_ref_poses.at(task_idx);
-
-            // Rviz puts arrows along x-axis by default. So, get the quaternion representation of the affordance screw
-            // axis wrt to the x-axis.
-            Eigen::Quaterniond aff_screw_quat;
-            aff_screw_quat.setFromTwoVectors(Eigen::Vector3d::UnitX(),
-                                             Eigen::Vector3d(aff_screw_axis.x, aff_screw_axis.y, aff_screw_axis.z));
-
-            // Fill out the pose
-            Eigen::Isometry3d aff_screw_pose;
-            aff_screw_pose.linear() = aff_screw_quat.toRotationMatrix();
-            aff_screw_pose.translation() = Eigen::Vector3d(aff_location.x, aff_location.y, aff_location.z);
-
-            // Translate the pose to planning frame
-            aff_screw_pose = T_w_r * aff_screw_pose;
-
-            // If affordance ref frame is specified, draw it
-            if (this->is_pose_specified(aff_ref_pose_msg))
+            // Truncate trajectories for visualization if violation was found
+            trajectory_msgs::msg::JointTrajectory viz_joint_traj = ordered_robot_traj;
+            auto viz_cart_traj = serv_req->cartesian_traj;
+            if (violation_found && first_violation_index > 0)
             {
-                Eigen::Isometry3d aff_ref_pose = this->transform_pose_to_world_frame(T_w_r, aff_ref_pose_msg);
-
-                rviz_visual_tools_->publishAxis(aff_ref_pose, rviz_visual_tools::Scales::LARGE);
+                // Keep only the points up to (but not including) the violation point for visualization
+                viz_joint_traj.points.resize(first_violation_index);
+                viz_cart_traj.resize(first_violation_index);
             }
 
-            // Publish
-            rviz_visual_tools_->publishArrow(aff_screw_pose, rviz_visual_tools::CYAN, rviz_visual_tools::LARGE);
-	}
-        
-	if (has_viz_traj) {
-            // Publish the joint trajectory
-	    moveit_msgs::msg::DisplayTrajectory display_trajectory;
+            const bool has_viz_traj =
+                !viz_joint_traj.points.empty(); // Check if there's anything to visualize after truncation
 
-	    // Set start state 
-	    display_trajectory.trajectory_start.joint_state.name     = viz_joint_traj.joint_names;
-	    display_trajectory.trajectory_start.joint_state.position = viz_joint_traj.points.front().positions;
+            // Capture T_w_r, the HTM from world frame, usually the root frame of the urdf to the service request
+            // reference frame
+            Eigen::Isometry3d T_w_r = current_state.getGlobalLinkTransform(serv_req->ref_frame);
 
-	    // Fill out the trajectory
-	    auto &robot_traj = display_trajectory.trajectory.emplace_back();
-	    robot_traj.joint_trajectory = viz_joint_traj;
-
-	    moveit_planned_path_pub_->publish(display_trajectory);
-                
-        // Publish the tool trajectory
-	        for (const auto& pose : viz_cart_traj)
-	        {
-	            rviz_visual_tools_->publishAxis(this->transform_pose_to_world_frame(T_w_r, pose));
-	        }
+            // Validate affordance info sizes
+            if (serv_req->aff_screw_axes.size() != serv_req->aff_locations.size() ||
+                serv_req->aff_screw_axes.size() != serv_req->aff_ref_poses.size())
+            {
+                RCLCPP_ERROR(node_logger_,
+                             "Mismatch in the size of affordance screw axes, locations, and reference pose vectors");
+                return;
             }
-	        rviz_visual_tools_->trigger();  // only once after batching
-        }
+
+            {
+                std::lock_guard<std::mutex> viz_lock(viz_mutex_);
+
+                // Clear messages
+                rviz_visual_tools_->deleteAllMarkers();
+
+                // Draw affordance screw axes and optionally, aff ref frames
+                for (size_t task_idx = 0; task_idx < serv_req->aff_screw_axes.size(); ++task_idx)
+                {
+                    const auto aff_screw_axis = serv_req->aff_screw_axes.at(task_idx);
+                    const auto aff_location = serv_req->aff_locations.at(task_idx);
+                    const auto aff_ref_pose_msg = serv_req->aff_ref_poses.at(task_idx);
+
+                    // Rviz puts arrows along x-axis by default. So, get the quaternion representation of the affordance
+                    // screw axis wrt to the x-axis.
+                    Eigen::Quaterniond aff_screw_quat;
+                    aff_screw_quat.setFromTwoVectors(
+                        Eigen::Vector3d::UnitX(),
+                        Eigen::Vector3d(aff_screw_axis.x, aff_screw_axis.y, aff_screw_axis.z));
+
+                    // Fill out the pose
+                    Eigen::Isometry3d aff_screw_pose;
+                    aff_screw_pose.linear() = aff_screw_quat.toRotationMatrix();
+                    aff_screw_pose.translation() = Eigen::Vector3d(aff_location.x, aff_location.y, aff_location.z);
+
+                    // Translate the pose to planning frame
+                    aff_screw_pose = T_w_r * aff_screw_pose;
+
+                    // If affordance ref frame is specified, draw it
+                    if (this->is_pose_specified(aff_ref_pose_msg))
+                    {
+                        Eigen::Isometry3d aff_ref_pose = this->transform_pose_to_world_frame(T_w_r, aff_ref_pose_msg);
+
+                        rviz_visual_tools_->publishAxis(aff_ref_pose, rviz_visual_tools::Scales::LARGE);
+                    }
+
+                    // Publish
+                    rviz_visual_tools_->publishArrow(aff_screw_pose, rviz_visual_tools::CYAN, rviz_visual_tools::LARGE);
+                }
+
+                if (has_viz_traj)
+                {
+                    // Publish the joint trajectory
+                    moveit_msgs::msg::DisplayTrajectory display_trajectory;
+
+                    // Set start state
+                    display_trajectory.trajectory_start.joint_state.name = viz_joint_traj.joint_names;
+                    display_trajectory.trajectory_start.joint_state.position = viz_joint_traj.points.front().positions;
+
+                    // Fill out the trajectory
+                    auto &robot_traj = display_trajectory.trajectory.emplace_back();
+                    robot_traj.joint_trajectory = viz_joint_traj;
+
+                    moveit_planned_path_pub_->publish(display_trajectory);
+
+                    // Publish the tool trajectory
+                    for (const auto &pose : viz_cart_traj)
+                    {
+                        rviz_visual_tools_->publishAxis(this->transform_pose_to_world_frame(T_w_r, pose));
+                    }
+                }
+                rviz_visual_tools_->trigger(); // only once after batching
+            }
         }
 
-	// Set response
-	if (violation_found) {
-	    RCLCPP_WARN(node_logger_, "Constraint violation at point index %zu", first_violation_index);
+        // Set response
+        if (violation_found)
+        {
+            RCLCPP_WARN(node_logger_, "Constraint violation at point index %zu", first_violation_index);
             // Index of the last valid point in the trajectory
-            if (first_violation_index > 0) {
+            if (first_violation_index > 0)
+            {
                 serv_res->valid_end_index = static_cast<uint32_t>(first_violation_index - 1);
-            } else {
+            }
+            else
+            {
                 serv_res->valid_end_index = 0;
             }
-	    serv_res->success = false;
-	} else {
-	    RCLCPP_INFO(node_logger_, "Successfully validated requested joint trajectory");
-	    serv_res->success = true;
-	}
+            serv_res->success = false;
+        }
+        else
+        {
+            RCLCPP_INFO(node_logger_, "Successfully validated requested joint trajectory");
+            serv_res->success = true;
+        }
         serv_res->validation_time_usecs = total_viol_check_duration.count(); // in microseconds
     }
 };
@@ -475,7 +500,8 @@ int main(int argc, char **argv)
 {
     rclcpp::init(argc, argv);
     rclcpp::NodeOptions node_options;
-    node_options.automatically_declare_parameters_from_overrides(true); // Useful to extract params from sensors_3d.yaml where we don't know sensor names beforehand
+    node_options.automatically_declare_parameters_from_overrides(
+        true); // Useful to extract params from sensors_3d.yaml where we don't know sensor names beforehand
     auto node = std::make_shared<CcaRosValAndVizServer>(node_options);
     node->initialize();
 

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -348,7 +348,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
 
 		// Check and store violation check
 		bool joint_limit_violation = !goal_state.satisfiesBounds(joint_model_group_);
-		lscene->checkSelfCollision(collision_request, collision_result, goal_state);
+		lscene->checkCollision(collision_request, collision_result, goal_state);
 		bool self_collision_violation = collision_result.collision;
 
 		// Capture how long it took to check for violations

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -252,7 +252,8 @@ class CcaRosValAndVizServer : public rclcpp::Node
 
         serv_res->success = false;// start as false
 
-        RCLCPP_INFO(node_logger_, "Planning and visualizing the trajectory");
+        RCLCPP_INFO(node_logger_, "Validating requested joint trajectory for planning group [%s] with reference frame [%s]",
+		    serv_req->planning_group.c_str(), serv_req->ref_frame.c_str());
 
         // Get fresh robot state
         moveit::core::RobotState current_state(*robot_state_);
@@ -260,19 +261,6 @@ class CcaRosValAndVizServer : public rclcpp::Node
             planning_scene_monitor::LockedPlanningSceneRO scene(psm_);
             current_state = scene->getCurrentState();
         }
-
-        // Capture T_w_r, the HTM from world frame, usually the root frame of the urdf to the service request reference
-        // frame
-        Eigen::Isometry3d T_w_r = current_state.getGlobalLinkTransform(serv_req->ref_frame);
-
-        // Validate affordance info sizes
-        if (serv_req->aff_screw_axes.size() != serv_req->aff_locations.size() ||
-	    serv_req->aff_screw_axes.size() != serv_req->aff_ref_poses.size())
-	{
-	    RCLCPP_ERROR(node_logger_,
-			 "Mismatch in the size of affordance screw axes, locations, and reference pose vectors");
-	    return;
-	}
 
         // Get the joint model group for the requested planning group
         moveit::core::JointModelGroup *joint_model_group = robot_model_->getJointModelGroup(serv_req->planning_group);
@@ -373,6 +361,8 @@ class CcaRosValAndVizServer : public rclcpp::Node
             }
 	    ++pt_index;
         }
+        if (serv_req->visualize){
+        RCLCPP_INFO(node_logger_, "Visualizing requested joint trajectory");
 
 	// Transform the trajectory to the full robot trajectory for visualization, i.e. by adding the current state of the unplanned joints
 	trajectory_msgs::msg::JointTrajectory ordered_robot_traj = reorder_trajectory_(serv_req->joint_traj, current_state.getVariableNames(), current_state);
@@ -388,22 +378,20 @@ class CcaRosValAndVizServer : public rclcpp::Node
 
 	const bool has_viz_traj = !viz_joint_traj.points.empty(); // Check if there's anything to visualize after truncation
 
-	if (has_viz_traj) {
-	    moveit_msgs::msg::DisplayTrajectory display_trajectory;
+        // Capture T_w_r, the HTM from world frame, usually the root frame of the urdf to the service request reference
+        // frame
+        Eigen::Isometry3d T_w_r = current_state.getGlobalLinkTransform(serv_req->ref_frame);
 
-	    // Set start state 
-	    display_trajectory.trajectory_start.joint_state.name     = viz_joint_traj.joint_names;
-	    display_trajectory.trajectory_start.joint_state.position = viz_joint_traj.points.front().positions;
+        // Validate affordance info sizes
+        if (serv_req->aff_screw_axes.size() != serv_req->aff_locations.size() ||
+	    serv_req->aff_screw_axes.size() != serv_req->aff_ref_poses.size())
+	{
+	    RCLCPP_ERROR(node_logger_,
+			 "Mismatch in the size of affordance screw axes, locations, and reference pose vectors");
+	    return;
+	}
 
-	    // Fill out the trajectory
-	    auto &robot_traj = display_trajectory.trajectory.emplace_back();
-	    robot_traj.joint_trajectory = viz_joint_traj;
-
-	    // Publish the joint trajectory -- I understand this is thread-safe so, no mutex needed.
-	    moveit_planned_path_pub_->publish(display_trajectory);
-         }
-
-        if (serv_req->visualize){
+         {
         std::lock_guard<std::mutex> viz_lock(viz_mutex_);
 
         // Clear messages
@@ -441,8 +429,21 @@ class CcaRosValAndVizServer : public rclcpp::Node
             rviz_visual_tools_->publishArrow(aff_screw_pose, rviz_visual_tools::CYAN, rviz_visual_tools::LARGE);
 	}
         
-            // Publish the tool trajectory
 	if (has_viz_traj) {
+            // Publish the joint trajectory
+	    moveit_msgs::msg::DisplayTrajectory display_trajectory;
+
+	    // Set start state 
+	    display_trajectory.trajectory_start.joint_state.name     = viz_joint_traj.joint_names;
+	    display_trajectory.trajectory_start.joint_state.position = viz_joint_traj.points.front().positions;
+
+	    // Fill out the trajectory
+	    auto &robot_traj = display_trajectory.trajectory.emplace_back();
+	    robot_traj.joint_trajectory = viz_joint_traj;
+
+	    moveit_planned_path_pub_->publish(display_trajectory);
+                
+        // Publish the tool trajectory
 	        for (const auto& pose : viz_cart_traj)
 	        {
 	            rviz_visual_tools_->publishAxis(this->transform_pose_to_world_frame(T_w_r, pose));
@@ -450,10 +451,11 @@ class CcaRosValAndVizServer : public rclcpp::Node
             }
 	        rviz_visual_tools_->trigger();  // only once after batching
         }
+        }
 
 	// Set response
 	if (violation_found) {
-	    RCLCPP_WARN(node_logger_, "Visualized trajectory up to violation point (first %zu points)", first_violation_index);
+	    RCLCPP_WARN(node_logger_, "Constraint violation at point index %zu", first_violation_index);
             // Index of the last valid point in the trajectory
             if (first_violation_index > 0) {
                 serv_res->valid_end_index = static_cast<uint32_t>(first_violation_index - 1);
@@ -462,7 +464,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
             }
 	    serv_res->success = false;
 	} else {
-	    RCLCPP_INFO(node_logger_, "Successfully validated and visualized requested joint trajectory");
+	    RCLCPP_INFO(node_logger_, "Successfully validated requested joint trajectory");
 	    serv_res->success = true;
 	}
         serv_res->validation_time_usecs = total_viol_check_duration.count(); // in microseconds

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -386,7 +386,9 @@ class CcaRosValAndVizServer : public rclcpp::Node
             viz_cart_traj.resize(first_violation_index);
 	}
 
-	if (!viz_joint_traj.points.empty()) {
+	const bool has_viz_traj = !viz_joint_traj.points.empty(); // Check if there's anything to visualize after truncation
+
+	if (has_viz_traj) {
 	    moveit_msgs::msg::DisplayTrajectory display_trajectory;
 
 	    // Set start state 
@@ -440,7 +442,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
 	}
         
             // Publish the tool trajectory
-	if (!viz_joint_traj.points.empty()) {
+	if (has_viz_traj) {
 	        for (const auto& pose : viz_cart_traj)
 	        {
 	            rviz_visual_tools_->publishAxis(this->transform_pose_to_world_frame(T_w_r, pose));

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -252,12 +252,6 @@ class CcaRosValAndVizServer : public rclcpp::Node
 
         serv_res->success = false;// start as false
 
-        {
-            std::lock_guard<std::mutex> viz_lock(viz_mutex_);
-        // Clear messages
-        rviz_visual_tools_->deleteAllMarkers();
-	}
-
         RCLCPP_INFO(node_logger_, "Planning and visualizing the trajectory");
 
         // Get fresh robot state
@@ -279,43 +273,6 @@ class CcaRosValAndVizServer : public rclcpp::Node
 			 "Mismatch in the size of affordance screw axes, locations, and reference pose vectors");
 	    return;
 	}
-
-        // Draw affordance screw axes and optionally, aff ref frames
-        {
-            std::lock_guard<std::mutex> viz_lock(viz_mutex_);
-        for (size_t task_idx = 0; task_idx < serv_req->aff_screw_axes.size(); ++task_idx){
-            const auto aff_screw_axis = serv_req->aff_screw_axes.at(task_idx);
-	    const auto aff_location = serv_req->aff_locations.at(task_idx);
-            const auto aff_ref_pose_msg = serv_req->aff_ref_poses.at(task_idx);
-
-            // Rviz puts arrows along x-axis by default. So, get the quaternion representation of the affordance screw
-            // axis wrt to the x-axis.
-            Eigen::Quaterniond aff_screw_quat;
-            aff_screw_quat.setFromTwoVectors(Eigen::Vector3d::UnitX(),
-                                             Eigen::Vector3d(aff_screw_axis.x, aff_screw_axis.y, aff_screw_axis.z));
-
-            // Fill out the pose
-            Eigen::Isometry3d aff_screw_pose;
-            aff_screw_pose.linear() = aff_screw_quat.toRotationMatrix();
-            aff_screw_pose.translation() = Eigen::Vector3d(aff_location.x, aff_location.y, aff_location.z);
-
-            // Translate the pose to planning frame
-            aff_screw_pose = T_w_r * aff_screw_pose;
-
-            // If affordance ref frame is specified, draw it
-            if (this->is_pose_specified(aff_ref_pose_msg))
-            {
-                Eigen::Isometry3d aff_ref_pose = this->transform_pose_to_world_frame(T_w_r, aff_ref_pose_msg);
-
-                rviz_visual_tools_->publishAxis(aff_ref_pose, rviz_visual_tools::Scales::LARGE);
-            }
-
-            // Publish
-            rviz_visual_tools_->publishArrow(aff_screw_pose, rviz_visual_tools::CYAN, rviz_visual_tools::LARGE);
-            rviz_visual_tools_->trigger();
-	}
-
-        }
 
         // Get the joint model group for the requested planning group
         moveit::core::JointModelGroup *joint_model_group_ = robot_model_->getJointModelGroup(serv_req->planning_group);
@@ -440,18 +397,56 @@ class CcaRosValAndVizServer : public rclcpp::Node
 	    auto &robot_traj = display_trajectory.trajectory.emplace_back();
 	    robot_traj.joint_trajectory = viz_joint_traj;
 
-	    // Publish the joint trajectory
+	    // Publish the joint trajectory -- I understand this is thread-safe so, no mutex needed.
 	    moveit_planned_path_pub_->publish(display_trajectory);
+         }
 
-            // Publish the tool trajectory
+        {
+        std::lock_guard<std::mutex> viz_lock(viz_mutex_);
+
+        // Clear messages
+        rviz_visual_tools_->deleteAllMarkers();
+
+        // Draw affordance screw axes and optionally, aff ref frames
+        for (size_t task_idx = 0; task_idx < serv_req->aff_screw_axes.size(); ++task_idx){
+            const auto aff_screw_axis = serv_req->aff_screw_axes.at(task_idx);
+	    const auto aff_location = serv_req->aff_locations.at(task_idx);
+            const auto aff_ref_pose_msg = serv_req->aff_ref_poses.at(task_idx);
+
+            // Rviz puts arrows along x-axis by default. So, get the quaternion representation of the affordance screw
+            // axis wrt to the x-axis.
+            Eigen::Quaterniond aff_screw_quat;
+            aff_screw_quat.setFromTwoVectors(Eigen::Vector3d::UnitX(),
+                                             Eigen::Vector3d(aff_screw_axis.x, aff_screw_axis.y, aff_screw_axis.z));
+
+            // Fill out the pose
+            Eigen::Isometry3d aff_screw_pose;
+            aff_screw_pose.linear() = aff_screw_quat.toRotationMatrix();
+            aff_screw_pose.translation() = Eigen::Vector3d(aff_location.x, aff_location.y, aff_location.z);
+
+            // Translate the pose to planning frame
+            aff_screw_pose = T_w_r * aff_screw_pose;
+
+            // If affordance ref frame is specified, draw it
+            if (this->is_pose_specified(aff_ref_pose_msg))
             {
-                std::lock_guard<std::mutex> viz_lock(viz_mutex_);
+                Eigen::Isometry3d aff_ref_pose = this->transform_pose_to_world_frame(T_w_r, aff_ref_pose_msg);
+
+                rviz_visual_tools_->publishAxis(aff_ref_pose, rviz_visual_tools::Scales::LARGE);
+            }
+
+            // Publish
+            rviz_visual_tools_->publishArrow(aff_screw_pose, rviz_visual_tools::CYAN, rviz_visual_tools::LARGE);
+	}
+        
+            // Publish the tool trajectory
+	if (!viz_joint_traj.points.empty()) {
 	        for (const auto& pose : viz_cart_traj)
 	        {
 	            rviz_visual_tools_->publishAxis(this->transform_pose_to_world_frame(T_w_r, pose));
 	        }
-	        rviz_visual_tools_->trigger();  // only once after batching
             }
+	        rviz_visual_tools_->trigger();  // only once after batching
         }
 
 	// Set response

--- a/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
+++ b/cca_ros_val_and_viz/src/cca_ros_val_and_viz_node.cpp
@@ -336,7 +336,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
             {
                 planning_scene_monitor::LockedPlanningSceneRO lscene(psm_);
 
-		// Check for joint limit and self-collision violation
+		// Check for joint limit and collision violation
 		auto start_time = std::chrono::high_resolution_clock::now(); // start time for this point in traj
 
 		// Set up collision requests and results
@@ -349,7 +349,7 @@ class CcaRosValAndVizServer : public rclcpp::Node
 		// Check and store violation check
 		bool joint_limit_violation = !goal_state.satisfiesBounds(joint_model_group_);
 		lscene->checkCollision(collision_request, collision_result, goal_state);
-		bool self_collision_violation = collision_result.collision;
+		bool collision_violation = collision_result.collision;
 
 		// Capture how long it took to check for violations
 		auto end_time = std::chrono::high_resolution_clock::now(); // stop time for this point in traj
@@ -357,11 +357,11 @@ class CcaRosValAndVizServer : public rclcpp::Node
 		total_viol_check_duration += point_duration;
 
 		// Log violation
-		if (joint_limit_violation || self_collision_violation) {
+		if (joint_limit_violation || collision_violation) {
 
 		    std::string violation_type =
-                    (joint_limit_violation && self_collision_violation) ? "Joint Limit Violation & Self-Collision" :
-                    joint_limit_violation ? "Joint Limit Violation" : "Self-Collision";
+                    (joint_limit_violation && collision_violation) ? "Joint Limit Violation & Collision" :
+                    joint_limit_violation ? "Joint Limit Violation" : "Collision";
 
 		    
 		    const double* goal_positions = goal_state.getVariablePositions();
@@ -376,8 +376,8 @@ class CcaRosValAndVizServer : public rclcpp::Node
 		    RCLCPP_ERROR(node_logger_, "Generated trajectory violates constraints [%s] at point[%zu]: [%s]",
 		    	     violation_type.c_str(), pt_index, oss.str().c_str());
 
-		    // If self-collision occurs, print the contacts
-		    if (self_collision_violation){
+		    // If collision occurs, print the contacts
+		    if (collision_violation){
 			    collision_detection::CollisionResult::ContactMap::const_iterator it;
 			    for (it = collision_result.contacts.begin(); it != collision_result.contacts.end(); ++it)
 			    {
@@ -458,6 +458,7 @@ int main(int argc, char **argv)
 {
     rclcpp::init(argc, argv);
     rclcpp::NodeOptions node_options;
+    node_options.automatically_declare_parameters_from_overrides(true); // Useful to extract params from sensors_3d.yaml where we don't know sensor names beforehand
     auto node = std::make_shared<CcaRosValAndVizServer>(node_options);
     node->initialize();
 

--- a/ros_cpp_util/include/ros_cpp_util/ros_cpp_util.hpp
+++ b/ros_cpp_util/include/ros_cpp_util/ros_cpp_util.hpp
@@ -3,31 +3,6 @@
 //      Project   : ros_cpp_util
 //      Created   : Fall 2023
 //      Author    : Janak Panthi (Crasun Jans)
-//      Copyright : Copyright© The University of Texas at Austin, 2014-2026. All
-//      rights reserved.
-//
-//          All files within this directory are subject to the following, unless
-//          an alternative license is explicitly included within the text of
-//          each file.
-//
-//          This software and documentation constitute an unpublished work
-//          and contain valuable trade secrets and proprietary information
-//          belonging to the University. None of the foregoing material may be
-//          copied or duplicated or disclosed without the express, written
-//          permission of the University. THE UNIVERSITY EXPRESSLY DISCLAIMS ANY
-//          AND ALL WARRANTIES CONCERNING THIS SOFTWARE AND DOCUMENTATION,
-//          INCLUDING ANY WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
-//          PARTICULAR PURPOSE, AND WARRANTIES OF PERFORMANCE, AND ANY WARRANTY
-//          THAT MIGHT OTHERWISE ARISE FROM COURSE OF DEALING OR USAGE OF TRADE.
-//          NO WARRANTY IS EITHER EXPRESS OR IMPLIED WITH RESPECT TO THE USE OF
-//          THE SOFTWARE OR DOCUMENTATION. Under no circumstances shall the
-//          University be liable for incidental, special, indirect, direct or
-//          consequential damages or loss of profits, interruption of business,
-//          or related expenses which may arise from use of software or
-//          documentation, including but not limited to those resulting from
-//          defects in software and/or documentation, or loss or inaccuracy of
-//          data of any kind.
-//
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef ROS_CPP_UTIL_HPP_
 #define ROS_CPP_UTIL_HPP_


### PR DESCRIPTION
This pull request introduces significant architectural and documentation improvements. It adds a new `CcaRosContext` class that encapsulates shared ROS resources (e.g., state subscriptions and parameter access), enabling multiple `CcaRos` planner instances to safely operate in parallel.

The PR also updates the validation server to handle concurrent requests (replacing the previous single-threaded spinner model), adds environmental collision checking, improves clarity around coding conventions and project structure, and includes minor API refinements. Additionally, it introduces two new packages, `cca_ros_features` and `cca_ros_behavior_features`, which leverage the parallel planning architecture to support higher-level capabilities such as affordative grasp pose evaluation. Lastly, note that the `cca_rviz_plugin` package `README.md` is updated to showcase the various planning types with relevant demo videos.

Key details:

### Architecture and Resource Sharing

* Introduced the `CcaRosContext` class, which encapsulates shared ROS resources (node, joint states subscriber, TF buffer/listener, planning group info) to allow multiple `CcaRos` planners to efficiently share infrastructure. This reduces resource duplication and startup overhead. New constructors and accessors were added to `CcaRos` to support this model. [[1]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450R151-R208) [[2]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450R223-R240) [[3]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL9-R88)
* Refactored `CcaRos` to use the shared context for all ROS infrastructure, moving relevant members and logic out of the planner class and into `CcaRosContext`. Per-planner resources (like action clients) are now managed separately. [[1]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450R327-R353) [[2]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450L301-R372) [[3]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450L317-L320) [[4]](diffhunk://#diff-eee1a911a8284959b9cff621c31024ea6c7285c6ee30b42c9f1c6a2fdceb957fL9-R88)

### API and Usability Improvements

* Added a `visualize_trajectory` flag to the `PlanningRequest` struct and updated the validation/visualization method signature to support selective visualization. [[1]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450R113) [[2]](diffhunk://#diff-1f8d0e15b3ff5cd7cdafb234487d8f5d67121b0e31176d41f6d33b467cec4450R413-R418)

### Documentation and Guidance
* Updated the README.md to the cca_ros_rviz_plugin package to showcase plugin features with demo videos.
* Added a comprehensive `CLAUDE.md` file, outlining package structure, architecture, coding conventions, and code-change constraints for contributors and code assistants.
* Added a `.claude/settings.json` file to specify code assistant permissions, allowing read/write access but denying Bash commands.